### PR TITLE
talloc: Update distinfo with the currect SHA and size information

### DIFF
--- a/devel/talloc/distinfo
+++ b/devel/talloc/distinfo
@@ -1,2 +1,2 @@
-SHA256 (talloc-2.0.8.tar.gz) = 1ec11e635e0318dbbb014db38ff96e8dba3ce5f614eeb7d993b4a5b71c016783
-SIZE (talloc-2.0.8.tar.gz) = 433489
+SHA256 (talloc-2.1.0.tar.gz) = 0701393882647f823503e3aa075bc67d75c194b376822377dae2d20f9130f08f
+SIZE (talloc-2.1.0.tar.gz) = 416097


### PR DESCRIPTION
The talloc Makefile uses talloc 2.1.0 but the distinfo still has the old 2.0.8 files, so the port will fail.
