### PR TITLE
Cassandra fails to install, wrong file name

### DIFF
--- a/README
+++ b/README
@@ -15,7 +15,7 @@ These will explain how to use ports and packages.
 
 If you would like to search for a port, you can do so easily by
 saying (in /usr/ports):
-
+asdasdasdasd
 
 	make search name="<name>"
 	or:

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ These will explain how to use ports and packages.
 
 If you would like to search for a port, you can do so easily by
 saying (in /usr/ports):
-asdasdasdasd
+asdasdasdasd111
 
 	make search name="<name>"
 	or:

--- a/README
+++ b/README
@@ -1,3 +1,6 @@
+TEST
+
+
 This is the FreeBSD Ports Collection.  For an easy to use
 WEB-based interface to it, please see:
 

--- a/graphics/libosmesa/Makefile
+++ b/graphics/libosmesa/Makefile
@@ -2,8 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	libosmesa
-PORTVERSION=	10.1.1
-PORTREVISION=	1
+PORTVERSION=	10.1.3
 CATEGORIES=	graphics
 MASTER_SITES=	ftp://ftp.freedesktop.org/pub/mesa/${PORTVERSION}/
 DISTNAME=	MesaLib-${PORTVERSION}
@@ -14,11 +13,11 @@ COMMENT=	Off-Screen Mesa implementation of the OpenGL API
 LIB_DEPENDS=	libexpat.so:${PORTSDIR}/textproc/expat2
 BUILD_DEPENDS=	${PYTHON_SITELIBDIR}/libxml2mod.so:${PORTSDIR}/textproc/py-libxml2
 
-USES+=		gmake pkgconfig tar:bzip2
+USES=		gmake pkgconfig tar:bzip2 libtool
 USE_LDCONFIG=	yes
 USE_PYTHON=	2
 USE_XORG=	x11 xext
-USE_AUTOTOOLS=	autoconf automake libtool
+USE_AUTOTOOLS=	autoconf automake libtool:env
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS+=--enable-osmesa \
 		--disable-driglx-direct \

--- a/graphics/libosmesa/distinfo
+++ b/graphics/libosmesa/distinfo
@@ -1,2 +1,2 @@
-SHA256 (MesaLib-10.1.1.tar.bz2) = f3ae730ed81fffcb1ec59076813f9955157da7a1dd9ba23a6b1b8ff8cf6798b0
-SIZE (MesaLib-10.1.1.tar.bz2) = 6948871
+SHA256 (MesaLib-10.1.3.tar.bz2) = b2615e236ef25d0fb94b8420bdd2e2a520b7dd5ca2d4b93306154f7fd4adecc3
+SIZE (MesaLib-10.1.3.tar.bz2) = 6955142

--- a/security/zxid/Makefile
+++ b/security/zxid/Makefile
@@ -7,7 +7,7 @@ PORTREVISION=	1
 CATEGORIES=	security www
 MASTER_SITES=	http://zxid.org/
 EXTRACT_SUFX=	.tgz
-
+asdasdasd
 MAINTAINER=	clsung@FreeBSD.org
 COMMENT=	Open Source IdM for the Masses - SAML SSO
 

--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,6 +1,8 @@
 # Created by: Sergey A. Osokin <osa@FreeBSD.org>
 # $FreeBSD$
 
+update nginx
+
 PORTNAME=	nginx
 PORTVERSION=	1.6.0
 PORTEPOCH=	2


### PR DESCRIPTION
The right file name is %%CQL%%%%DATADIR%%/lib/cql-internal-only-1.4.1.zip below is the build error:

===>  Installing for cassandra-1.2.15
===>  Checking if databases/cassandra already installed
===>   Registering installation for cassandra-1.2.15
pkg-static: lstat(/var/tmp/usr/ports/databases/cassandra/work/stage/usr/local/share/cassandra/lib/cql-internal-only-1.4.0.zip): No such file or directory
*** Error code 74

Stop.
make: stopped in /usr/ports/databases/cassandra
