### PR TITLE
virtualbox-ose-lite minimal deps for packaging

### DIFF
--- a/emulators/Makefile
+++ b/emulators/Makefile
@@ -148,6 +148,7 @@
     SUBDIR += virtualbox-ose
     SUBDIR += virtualbox-ose-additions
     SUBDIR += virtualbox-ose-kmod
+    SUBDIR += virtualbox-ose-lite
     SUBDIR += visualboyadvance-m
     SUBDIR += vmips
     SUBDIR += vmsbackup

--- a/emulators/virtualbox-ose-lite/Makefile
+++ b/emulators/virtualbox-ose-lite/Makefile
@@ -1,0 +1,14 @@
+# Created by: Alfred Perlstein <alfred@freebsd.org>
+# $FreeBSD$
+
+PORTREVISION=   0
+
+MAINTAINER=     alfred@FreeBSD.org
+COMMENT=        Small install of virtualbox without graphics
+
+LITE=           yes
+
+MASTERDIR=      ${.CURDIR}/../virtualbox-ose
+
+.include "${MASTERDIR}/Makefile"
+

--- a/emulators/virtualbox-ose/Makefile
+++ b/emulators/virtualbox-ose/Makefile
@@ -47,6 +47,14 @@ CONFLICTS_INSTALL=	virtualbox-ose-additions-4* \
 			virtualbox-ose-devel-4* \
 			virtualbox-ose-legacy-4*
 
+.if defined(LITE)
+PKGNAMESUFFIX+=		-lite
+CONFLICTS_INSTALL+=      ${PORTNAME}-[0-9]*
+WITHOUT+=      		NLS
+.else
+CONFLICTS_INSTALL+=      ${PORTNAME}-lite-[0-9]*
+.endif
+
 VBOXUSER?=	vboxusers
 VBOXWSUSER?=	vboxusers
 VBOXGROUP?=	vboxusers
@@ -57,7 +65,11 @@ VBOX_GUEST_VER=	${PORTVERSION}
 
 OPTIONS_DEFINE=	DBUS DEBUG GUESTADDITIONS MANUAL NLS PULSEAUDIO PYTHON \
 		QT4 UDPTUNNEL VDE VNC VPX WEBSERVICE X11
+.if defined(LITE)
+OPTIONS_DEFAULT=	UDPTUNNEL VNC
+.else
 OPTIONS_DEFAULT=	DBUS PYTHON QT4 UDPTUNNEL VNC WEBSERVICE X11
+.endif
 OPTIONS_SUB=	yes
 
 DEBUG_DESC=	Debug symbols, additional logs and assertions


### PR DESCRIPTION
This package has minimal deps, only udp server and
vncserver are required.

This works really nicely for someone who just wants
to run headless vms or the VBoxManage tools without
bloat.