### PR TITLE
Elixir always expects UTF-8, make it default while compiling to avoid…

### DIFF
--- a/lang/elixir/Makefile
+++ b/lang/elixir/Makefile
@@ -20,5 +20,6 @@ GH_TAGNAME=	v${PORTVERSION}
 USES=	gmake
 
 ALL_TARGET=	#empty
+WITH_CHARSET=   utf8
 
 .include <bsd.port.mk>


### PR DESCRIPTION
… warning messages.

Elixir needs and expects UTF-8 and emits ```warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell)``` if not compiled with UTF-8.

This PR fixes that.

