### PR TITLE
py-pytest-runner: remove the version 2 forcing

### DIFF
--- a/devel/py-pytest-runner/Makefile
+++ b/devel/py-pytest-runner/Makefile
@@ -12,7 +12,7 @@ COMMENT=	Test support for pytest runner in setup.py
 
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}hgtools>=0:${PORTSDIR}/devel/py-hgtools
 
-USES=		python:2 zip
+USES=		python zip
 USE_PYTHON=	distutils autoplist
 
 .include <bsd.port.mk>


### PR DESCRIPTION
This fix the py34-pytest-runner build, and by side the py34-irc port build.