### PR TITLE
x11/libxkbcommon: Set correct x-locale path via CONFIGURE_ARGS.

### DIFF
--- a/x11/libxkbcommon/Makefile
+++ b/x11/libxkbcommon/Makefile
@@ -23,6 +23,7 @@ CONFIGURE_ARGS=	--without-default-layout \
 		--without-default-options \
 		--without-default-rules \
 		--without-default-variant \
-		--without-doxygen
+		--without-doxygen \
+		--with-x-locale-root=${PREFIX}/lib/X11/locale
 
 .include <bsd.port.mk>


### PR DESCRIPTION
This enables libxkbcommon to find the locale-specific key
composition rules installed by x11/libX11.