### PR TITLE
Add start_x.elf and fixup_x.dat files.

### DIFF
--- a/sysutils/u-boot-rpi/Makefile
+++ b/sysutils/u-boot-rpi/Makefile
@@ -31,8 +31,10 @@ PLIST_FILES=	${U_BOOT_DIR}/u-boot.img \
 		${U_BOOT_DIR}/config.txt \
 		${U_BOOT_DIR}/fixup.dat \
 		${U_BOOT_DIR}/fixup_cd.dat \
+		${U_BOOT_DIR}/fixup_x.dat \
 		${U_BOOT_DIR}/start.elf \
-		${U_BOOT_DIR}/start_cd.elf
+		${U_BOOT_DIR}/start_cd.elf \
+		${U_BOOT_DIR}/start_x.elf
 
 MAKE_ARGS+=	ARCH=arm \
 		CROSS_COMPILE=arm-none-eabi-


### PR DESCRIPTION
This fix adds missing firmware start_x.elf and fixup_x.dat files to boot partition for Raspberry PI (versions A and B). This is required for camera and additional codecs support.
