### PR TITLE
Update nzbget.in

### DIFF
--- a/news/nzbget/files/nzbget.in
+++ b/news/nzbget/files/nzbget.in
@@ -20,10 +20,10 @@ load_rc_config ${name}
 
 : ${nzbget_enable:=NO}
 
+command=%%PREFIX%%/bin/nzbget
 start_cmd="${name}_start"
 status_cmd="${command} -L S"
 stop_cmd="${name}_stop"
-command=%%PREFIX%%/bin/nzbget
 
 nzbget_start()
 {


### PR DESCRIPTION
Fix broken status command which was returning "eval: -L: not found" on my stock FreeBSD 10.2 system. Simply moved the "command" variable definition before the *_cmd variables.