### PR TITLE
add 3rd party upstream_health_check module to nginx

### DIFF
--- a/www/nginx-devel/Makefile
+++ b/www/nginx-devel/Makefile
@@ -86,6 +86,7 @@ OPTIONS_DEFINE=	\
 	HTTP_TARANTOOL \
 	HTTP_UPLOAD \
 	HTTP_UPLOAD_PROGRESS \
+	HTTP_UPSTREAM_HEALTH \
 	HTTP_UPSTREAM_FAIR \
 	HTTP_UPSTREAM_STICKY \
 	HTTP_ZIP \
@@ -187,6 +188,7 @@ HTTP_SUBS_FILTER_DESC=		3rd party subs filter module
 HTTP_TARANTOOL_DESC=		3rd party tarantool upstream module
 HTTP_UPLOAD_DESC=		3rd party upload module
 HTTP_UPLOAD_PROGRESS_DESC=	3rd party uploadprogress module
+HTTP_UPSTREAM_HEALTH_DESC=     3rd party upstream_health_check_module
 HTTP_UPSTREAM_FAIR_DESC=	3rd party upstream fair module
 HTTP_UPSTREAM_STICKY_DESC=	3rd party upstream sticky module
 HTTP_ZIP_DESC=			3rd party http_zip module
@@ -606,6 +608,15 @@ GH_ACCOUNT+=	masterzen:uploadprogress
 GH_PROJECT+=	nginx-upload-progress-module:uploadprogress
 GH_TAGNAME+=	v${NGINX_UPLOADPROGRESS_VERSION}:uploadprogress
 CONFIGURE_ARGS+=--add-module=${WRKSRC_uploadprogress}
+.endif
+
+.if ${PORT_OPTIONS:MHTTP_UPSTREAM_HEALTH}
+GIT_UPSTREAM_HEALTH_VERSION=   10782ea
+GH_ACCOUNT+=   yaoweibin:upstream_health
+GH_PROJECT+=   nginx_upstream_check_module:upstream_health
+GH_TAGNAME+=   ${GIT_UPSTREAM_HEALTH_VERSION}:upstream_health
+EXTRA_PATCHES+=${WRKSRC_upstream_health}/check_1.9.2+.patch
+CONFIGURE_ARGS+=--add-module=${WRKSRC_upstream_health}
 .endif
 
 .if !empty(PORT_OPTIONS:MHTTP_UPSTREAM_FAIR)

--- a/www/nginx-devel/distinfo
+++ b/www/nginx-devel/distinfo
@@ -126,3 +126,5 @@ SHA256 (calio-form-input-nginx-module-v0.07_GH0.tar.gz) = c0c56cc697a290e98b88d4
 SIZE (calio-form-input-nginx-module-v0.07_GH0.tar.gz) = 10563
 SHA256 (calio-iconv-nginx-module-v0.10_GH0.tar.gz) = 88e326eba7fdf9fd2376b1ba033b48cb0eee45136528cf5430ac9340088ce324
 SIZE (calio-iconv-nginx-module-v0.10_GH0.tar.gz) = 12513
+SHA256 (yaoweibin-nginx_upstream_check_module-10782ea_GH0.tar.gz) = 52e6acd8c0264a59c5c948271015a59acd3cbcf91377456b7c8dc6f9feecef4a
+SIZE (yaoweibin-nginx_upstream_check_module-10782ea_GH0.tar.gz) = 128281

--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -82,6 +82,7 @@ OPTIONS_DEFINE=	\
 	HTTP_TARANTOOL \
 	HTTP_UPLOAD \
 	HTTP_UPLOAD_PROGRESS \
+	HTTP_UPSTREAM_HEALTH \
 	HTTP_UPSTREAM_FAIR \
 	HTTP_UPSTREAM_STICKY \
 	HTTP_ZIP \
@@ -178,6 +179,7 @@ HTTP_SUBS_FILTER_DESC=		3rd party subs filter module
 HTTP_TARANTOOL_DESC=		3rd party tarantool upstream module
 HTTP_UPLOAD_DESC=		3rd party upload module
 HTTP_UPLOAD_PROGRESS_DESC=	3rd party uploadprogress module
+HTTP_UPSTREAM_HEALTH_DESC=	3rd party upstream_health_check_module
 HTTP_UPSTREAM_FAIR_DESC=	3rd party upstream fair module
 HTTP_UPSTREAM_STICKY_DESC=	3rd party upstream sticky module
 HTTP_ZIP_DESC=			3rd party http_zip module
@@ -590,6 +592,15 @@ GH_ACCOUNT+=	masterzen:uploadprogress
 GH_PROJECT+=	nginx-upload-progress-module:uploadprogress
 GH_TAGNAME+=	v${NGINX_UPLOADPROGRESS_VERSION}:uploadprogress
 CONFIGURE_ARGS+=--add-module=${WRKSRC_uploadprogress}
+.endif
+
+.if ${PORT_OPTIONS:MHTTP_UPSTREAM_HEALTH}
+GIT_UPSTREAM_HEALTH_VERSION=	10782ea
+GH_ACCOUNT+=	yaoweibin:upstream_health
+GH_PROJECT+=	nginx_upstream_check_module:upstream_health
+GH_TAGNAME+=	${GIT_UPSTREAM_HEALTH_VERSION}:upstream_health
+EXTRA_PATCHES+=${WRKSRC_upstream_health}/check_1.7.5+.patch:-p1
+CONFIGURE_ARGS+=--add-module=${WRKSRC_upstream_health}
 .endif
 
 .if !empty(PORT_OPTIONS:MHTTP_UPSTREAM_FAIR)

--- a/www/nginx/distinfo
+++ b/www/nginx/distinfo
@@ -122,3 +122,5 @@ SHA256 (calio-form-input-nginx-module-v0.07_GH0.tar.gz) = c0c56cc697a290e98b88d4
 SIZE (calio-form-input-nginx-module-v0.07_GH0.tar.gz) = 10563
 SHA256 (calio-iconv-nginx-module-v0.10_GH0.tar.gz) = 88e326eba7fdf9fd2376b1ba033b48cb0eee45136528cf5430ac9340088ce324
 SIZE (calio-iconv-nginx-module-v0.10_GH0.tar.gz) = 12513
+SHA256 (yaoweibin-nginx_upstream_check_module-10782ea_GH0.tar.gz) = 52e6acd8c0264a59c5c948271015a59acd3cbcf91377456b7c8dc6f9feecef4a
+SIZE (yaoweibin-nginx_upstream_check_module-10782ea_GH0.tar.gz) = 128281


### PR DESCRIPTION
I'm not shure how to ask for adding those changes to the ports tree as this git repository is just a mirror of the FreeBSD-ports SVN repo. But I found this page https://wiki.freebsd.org/GitWorkflow/GitSvn. Is this the appropiate way? I found nothing about contribution in the porter's handbook. 