### PR TITLE
print/cloudprint: Added missing dependencies

### DIFF
--- a/print/cloudprint/Makefile
+++ b/print/cloudprint/Makefile
@@ -12,7 +12,9 @@ COMMENT=	Google Cloud Print proxy for local CUPS printers
 LICENSE=	GPLv3
 
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pycups>=0:print/py-pycups \
-		${PYTHON_PKGNAMEPREFIX}daemon>0:devel/py-daemon
+		${PYTHON_PKGNAMEPREFIX}daemon>0:devel/py-daemon \
+		${PYTHON_PKGNAMEPREFIX}argparse>=0:devel/py-argparse \		
+		${PYTHON_PKGNAMEPREFIX}requests>=2.7.0:www/py-requests
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	armooo


### PR DESCRIPTION
Added missing dependencies. cloudprint also needs requests and argparse.
setup.py also lists those as dependencies: https://raw.githubusercontent.com/armooo/cloudprint/master/setup.py

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=210674