### PR TITLE
Fixing compilation when using GSSAPI_MIT

### DIFF
--- a/sysutils/msktutil/Makefile
+++ b/sysutils/msktutil/Makefile
@@ -27,6 +27,7 @@ OPTIONS_DEFAULT=GSSAPI_BASE
 GSSAPI_BASE_USES=	gssapi
 GSSAPI_HEIMDAL_USES=	gssapi:heimdal
 GSSAPI_MIT_USES=	gssapi:mit
+GSSAPI_MIT_CONFIGURE_ON=        --with-krb5-config=/usr/local/bin/krb5-config --with-krb5dir=/usr/local --with-krb5=mit
 
 PLIST_FILES=	man/man1/msktutil.1.gz sbin/msktutil
 


### PR DESCRIPTION
When I try to compile msktutils with GSSAPI_MIT the build fail with messages below.

g++ -g -O2 -Wall -Wextra -Wno-write-strings -c krb5wrap.cpp -o krb5wrap.o
In file included from msktutil.h:341:0,
                 from krb5wrap.cpp:31:
krb5wrap.h: In member function 'krb5_enctype KRB5Keytab::cursor::enctype()':
krb5wrap.h:198:50: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
         return static_cast<krb5_enctype>(m_entry.keyblock.keytype);
                                                  ^
krb5wrap.cpp: In function 'krb5_error_code krb5_free_keytab_entry_contents(krb5_context, krb5_keytab_entry*)':
krb5wrap.cpp:38:20: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
         if (entry->keyblock.keyvalue.data) {
                    ^
krb5wrap.cpp:39:27: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
             memset(entry->keyblock.keyvalue.data, 0, entry->keyblock.keyvalue.length);
                           ^
krb5wrap.cpp:39:61: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
             memset(entry->keyblock.keyvalue.data, 0, entry->keyblock.keyvalue.length);
                                                             ^
krb5wrap.cpp:40:25: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
             free(entry->keyblock.keyvalue.data);
                         ^
krb5wrap.cpp: In member function 'void KRB5Keyblock::from_string(krb5_enctype, const string&, const string&)':
krb5wrap.cpp:81:5: error: 'krb5_salt' was not declared in this scope
     krb5_salt salt_data;
     ^
krb5wrap.cpp:83:5: error: 'salt_data' was not declared in this scope
     salt_data.salttype = KRB5_PW_SALT;
     ^
krb5wrap.cpp:83:26: error: 'KRB5_PW_SALT' was not declared in this scope
     salt_data.salttype = KRB5_PW_SALT;
                          ^
krb5wrap.cpp:91:89: error: 'krb5_string_to_key_data_salt' was not declared in this scope
                                                        pass_data, salt_data, &m_keyblock);
                                                                                         ^
krb5wrap.cpp: In member function 'std::__cxx11::string KRB5Principal::name()':
krb5wrap.cpp:163:32: error: 'krb5_xfree' was not declared in this scope
     krb5_xfree(principal_string);
                                ^
krb5wrap.cpp: In member function 'void KRB5Keytab::addEntry(KRB5Principal&, krb5_kvno, KRB5Keyblock&)':
krb5wrap.cpp:179:11: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
     entry.keyblock = keyblock.get();
           ^
krb5wrap.cpp: In member function 'void KRB5Keytab::removeEntry(KRB5Principal&, krb5_kvno, krb5_enctype)':
krb5wrap.cpp:197:11: error: 'krb5_keytab_entry {aka struct krb5_keytab_entry_st}' has no member named 'keyblock'
     entry.keyblock.keytype = enctype;
           ^
*** Error code 1

Stop.
make: stopped in /usr/ports/sysutils/msktutil/work/msktutil-1.0