### PR TITLE
sysutils/goss: Add rc script, sample configuration (221579)

### DIFF
--- a/sysutils/goss/Makefile
+++ b/sysutils/goss/Makefile
@@ -3,6 +3,7 @@
 PORTNAME=		goss
 PORTVERSION=		0.3.4
 DISTVERSIONPREFIX=	v
+PORTREVISION=		1
 CATEGORIES=	 	sysutils
 
 MAINTAINER=	 	englishm@llnw.com
@@ -16,7 +17,7 @@ BUILD_DEPENDS=		go:lang/go
 ONLY_FOR_ARCHS=		amd64
 ONLY_FOR_ARCHS_REASON=	go-ps only supports amd64
 
-PLIST_FILES=		bin/goss
+USE_RC_SUBR=		goss
 
 USE_GITHUB=	 	yes
 GH_ACCOUNT=	 	aelsabbahy
@@ -37,6 +38,10 @@ GH_TUPLE=		achanda:go-sysctl:6be7678:achanda/src/github.com/achanda/go-sysctl \
 			opencontainers:runc:8779fa5:opencontainers/src/github.com/opencontainers/runc \
 			patrickmn:go-cache:1881a9b:patrickmn/src/github.com/patrickmn/go-cache \
 			urfave:cli:d86a009:urfave/src/github.com/urfave/cli
+
+post-patch:
+	${REINPLACE_CMD} 's|%%PREFIX%%|${PREFIX}|' ${WRKSRC}/extras/goss.yaml.sample
+
 do-build:
 	@cd ${WRKSRC} && ${SETENV} ${MAKE_ENV} CGO_ENABLED=0 GOPATH=${WRKSRC} \
 	go build -ldflags "-X main.version=${DISTVERSIONPREFIX}${PORTVERSION} -s -w" -o \
@@ -45,5 +50,9 @@ do-build:
 do-install:
 	${INSTALL_PROGRAM} ${WRKSRC}/src/github.com/${GH_ACCOUNT}/${PORTNAME}/bin/${PORTNAME} \
 		${STAGEDIR}${PREFIX}/bin/${PORTNAME}
+	${INSTALL_DATA} ${WRKSRC}/extras/goss.yaml.sample ${STAGEDIR}${PREFIX}/etc/goss.yaml.sample
+	${MKDIR} ${STAGEDIR}${PREFIX}/etc/goss.d
+	${INSTALL_DATA} ${WRKSRC}/extras/process_goss.yaml.sample \
+		${STAGEDIR}${PREFIX}/etc/goss.d/process_goss.yaml.sample
 
 .include <bsd.port.mk>

--- a/sysutils/goss/files/goss.in
+++ b/sysutils/goss/files/goss.in
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Goss startup script
+#
+# PROVIDE: goss
+# REQUIRE: DAEMON
+# KEYWORD: shutdown
+
+# Add the following to /etc/rc.conf[.local] to enable this service
+#
+# goss_enable (bool):       Set to NO by default.
+#                           Set it to YES to enable goss
+# goss_conf (string):       Set to %%PREFIX%%/etc/goss.yaml by default
+#                           Set it to preferred config file
+# goss_listen (string):     Set to ":12345" by default
+#                           Set it to preferred listen address
+#
+
+. /etc/rc.subr
+
+name=goss
+rcvar=goss_enable
+
+load_rc_config $name
+
+: ${goss_enable:="NO"}
+: ${goss_listen="127.0.0.1:12345"}
+: ${goss_conf="%%PREFIX%%/etc/goss.yaml"}
+
+required_files=${goss_conf}
+pidfile=/var/run/${name}.pid
+procname="%%PREFIX%%/bin/goss"
+command="/usr/sbin/daemon"
+command_args="-f -p ${pidfile} /usr/bin/env ${goss_env} ${procname} -g ${goss_conf} serve -l ${goss_listen}"
+
+run_rc_command "$1"

--- a/sysutils/goss/files/patch-extras_goss.yaml.sample
+++ b/sysutils/goss/files/patch-extras_goss.yaml.sample
@@ -1,0 +1,6 @@
+--- extras/goss.yaml.sample.orig	2017-08-14 20:07:43 UTC
++++ extras/goss.yaml.sample
+@@ -0,0 +1,3 @@
++gossfile:
++  %%PREFIX%%/etc/goss.d/*.yaml: {}
++

--- a/sysutils/goss/files/patch-extras_process__goss.yaml.sample
+++ b/sysutils/goss/files/patch-extras_process__goss.yaml.sample
@@ -1,0 +1,6 @@
+--- extras/process_goss.yaml.sample.orig	2017-08-15 06:16:52 UTC
++++ extras/process_goss.yaml.sample
+@@ -0,0 +1,3 @@
++process:
++  goss:
++    running: true

--- a/sysutils/goss/pkg-plist
+++ b/sysutils/goss/pkg-plist
@@ -1,0 +1,4 @@
+@dir etc/goss.d
+@sample etc/goss.d/process_goss.yaml.sample
+@sample etc/goss.yaml.sample
+bin/goss


### PR DESCRIPTION
Adds an rc script to run `goss serve` as a health endpoint and sample configuration files to support the service.

Reference only.

Actual patch submitted as [Bug 221579](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=221579)