### PR TITLE
Fix build when python's DEFAULT_VERSION is 3.x

### DIFF
--- a/sysutils/uefi-edk2-bhyve/Makefile
+++ b/sysutils/uefi-edk2-bhyve/Makefile
@@ -15,7 +15,7 @@ BUILD_DEPENDS=	bash:shells/bash \
 		${PYTHON_LIBDIR}/lib-dynload/_sqlite3.so:databases/py-sqlite3
 
 USES=		gmake \
-		python:build
+		python:2,build
 USE_GCC=	4.8
 USE_GITHUB=	yes
 GH_ACCOUNT=	freebsd


### PR DESCRIPTION
Refer to FreeBSD Bugzilla PR 223357. This pull request is only for Hacktoberfest accounting purposes, so it may be closed at any time.