### PR TITLE
S3 files should ONLY appear in -server not -client

### DIFF
--- a/databases/mariadb105-client/pkg-plist
+++ b/databases/mariadb105-client/pkg-plist
@@ -88,7 +88,7 @@ libdata/pkgconfig/mariadb.pc
 @comment man/man1/aria_ftdump.1.gz
 @comment man/man1/aria_pack.1.gz
 @comment man/man1/aria_read_log.1.gz
-man/man1/aria_s3_copy.1.gz
+@comment man/man1/aria_s3_copy.1.gz
 @comment man/man1/galera_new_cluster.1.gz
 @comment man/man1/galera_recovery.1.gz
 @comment man/man1/innochecksum.1.gz


### PR DESCRIPTION
This line is causing -client and -server to conflict with each other by both attempting to install the same file to the same location. S3 is a -server storage engine item only, and has no relation to the -client package.

Referenced in:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=251622
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254969