### PR TITLE
Update package descriptions and messages for some VirtualBox ports

### DIFF
--- a/emulators/virtualbox-ose-additions-legacy/pkg-descr
+++ b/emulators/virtualbox-ose-additions-legacy/pkg-descr
@@ -1,9 +1,17 @@
-These additions are for installation inside a FreeBSD guest.
+For any serious and interactive use, the Oracleⓡ VM VirtualBoxⓡ 
+Guest Additions will make your life much easier by providing closer 
+integration between host and guest and improving the interactive 
+performance of guest systems. 
 
-VirtualBox is a family of powerful x86 virtualization products for
-enterprise as well as home use. Not only is VirtualBox an extremely
-feature rich, high performance product for enterprise customers, it
-is also the only professional solution that is freely available as
-Open Source Software under the terms of the GNU General Public License.
+Non-legacy additions i.e. emulators/virtualbox-ose-additions are 
+recommended for most use cases. 
 
-WWW: https://www.virtualbox.org/
+Where legacy (5.2.x) is a requirement, this FreeBSD-provided package 
+can be installed in the FreeBSD guest machine. 
+
+<https://www.virtualbox.org/wiki/Changelog-5.2> emphasises that 
+5.2.x is no longer supported by Oracle.
+
+Addition to host machines is not required. 
+
+WWW: https://www.virtualbox.org/manual/UserManual.html#guestadditions

--- a/emulators/virtualbox-ose-additions-legacy/pkg-descr
+++ b/emulators/virtualbox-ose-additions-legacy/pkg-descr
@@ -1,7 +1,5 @@
-For any serious and interactive use, the Oracleⓡ VM VirtualBoxⓡ 
-Guest Additions will make your life much easier by providing closer 
-integration between host and guest and improving the interactive 
-performance of guest systems. 
+VirtualBox Guest Additions provide closer integration between host and 
+guest, and improve the performance of guest systems. 
 
 Non-legacy additions i.e. emulators/virtualbox-ose-additions are 
 recommended for most use cases. 
@@ -14,4 +12,4 @@ can be installed in the FreeBSD guest machine.
 
 Addition to host machines is not required. 
 
-WWW: https://www.virtualbox.org/manual/UserManual.html#guestadditions
+WWW: https://www.virtualbox.org/

--- a/emulators/virtualbox-ose-additions-legacy/pkg-message
+++ b/emulators/virtualbox-ose-additions-legacy/pkg-message
@@ -1,7 +1,7 @@
 [
 { type: install
   message: <<EOM
-Oracleⓡ VirtualBoxⓡ Guest Additions are installed.
+VirtualBox Guest Additions are installed.
 
 To enable and start the required services: 
 

--- a/emulators/virtualbox-ose-additions-legacy/pkg-message
+++ b/emulators/virtualbox-ose-additions-legacy/pkg-message
@@ -1,23 +1,24 @@
 [
 { type: install
   message: <<EOM
-VirtualBox Guest Additions were installed.
+Oracleⓡ VirtualBoxⓡ Guest Additions are installed.
 
+To enable and start the required services: 
 
-You need to enable the vboxguest startscript to load the kernel module and
-vboxservice to use host time synchronization.
+# sysrc vboxguest_enable="YES" && service vboxguest start
+# sysrc vboxservice_enable="YES" && service vboxservice start
 
-vboxguest_enable="YES"
-vboxservice_enable="YES"
+The vboxguest service will load a required kernel module. 
 
-You also have to add all X11 users that want to use any of the additional
-features (clipboard sharing, window scaling) to the wheel group.
+For features such as window scaling and clipboard sharing, membership of 
+the wheel group is required. With username jerry as an example: 
 
-% pw groupmod wheel -m jerry
+# pw groupmod wheel -m jerry
 
-Reboot the machine to load the needed kernel modules.
-
-For detailed informations please visit http://wiki.freebsd.org/VirtualBox
+The settings dialogue for FreeBSD guests encourages use of the VMSVGA 
+graphics controller. Whilst this might suit installations of FreeBSD 
+without a desktop environment (a common use case), it may be inappropriate 
+where legacy Guest Additions are installed. 
 EOM
 }
 ]

--- a/emulators/virtualbox-ose-additions-legacy/pkg-message
+++ b/emulators/virtualbox-ose-additions-legacy/pkg-message
@@ -5,8 +5,8 @@ Oracleⓡ VirtualBoxⓡ Guest Additions are installed.
 
 To enable and start the required services: 
 
-# sysrc vboxguest_enable="YES" && service vboxguest start
-# sysrc vboxservice_enable="YES" && service vboxservice start
+# sysrc vboxguest_enable="YES" ; sync ; service vboxguest start
+# sysrc vboxservice_enable="YES" ; service vboxservice start
 
 The vboxguest service will load a required kernel module. 
 

--- a/emulators/virtualbox-ose-additions-legacy/pkg-message
+++ b/emulators/virtualbox-ose-additions-legacy/pkg-message
@@ -3,12 +3,12 @@
   message: <<EOM
 VirtualBox Guest Additions are installed.
 
-To enable and start the required services: 
+To enable the required services: 
 
-# sysrc vboxguest_enable="YES" ; sync ; service vboxguest start
-# sysrc vboxservice_enable="YES" ; service vboxservice start
+# sysrc vboxguest_enable="YES"
+# sysrc vboxservice_enable="YES"
 
-The vboxguest service will load a required kernel module. 
+To start the services, restart the system. 
 
 For features such as window scaling and clipboard sharing, membership of 
 the wheel group is required. With username jerry as an example: 

--- a/emulators/virtualbox-ose-additions/pkg-descr
+++ b/emulators/virtualbox-ose-additions/pkg-descr
@@ -1,10 +1,8 @@
-For any serious and interactive use, the Oracleⓡ VM VirtualBoxⓡ 
-Guest Additions will make your life much easier by providing closer 
-integration between host and guest and improving the interactive 
-performance of guest systems. 
+VirtualBox Guest Additions provide closer integration between host and 
+guest, and improve the performance of guest systems.
 
 This FreeBSD-provided package can be installed in FreeBSD guest machines. 
 
 Addition to host machines is not required. 
 
-WWW: https://www.virtualbox.org/manual/UserManual.html#guestadditions
+WWW: https://www.virtualbox.org/

--- a/emulators/virtualbox-ose-additions/pkg-descr
+++ b/emulators/virtualbox-ose-additions/pkg-descr
@@ -1,9 +1,10 @@
-These additions are for installation inside a FreeBSD guest.
+For any serious and interactive use, the Oracleⓡ VM VirtualBoxⓡ 
+Guest Additions will make your life much easier by providing closer 
+integration between host and guest and improving the interactive 
+performance of guest systems. 
 
-VirtualBox is a family of powerful x86 virtualization products for
-enterprise as well as home use. Not only is VirtualBox an extremely
-feature rich, high performance product for enterprise customers, it
-is also the only professional solution that is freely available as
-Open Source Software under the terms of the GNU General Public License.
+This FreeBSD-provided package can be installed in FreeBSD guest machines. 
 
-WWW: https://www.virtualbox.org/
+Addition to host machines is not required. 
+
+WWW: https://www.virtualbox.org/manual/UserManual.html#guestadditions

--- a/emulators/virtualbox-ose-additions/pkg-message
+++ b/emulators/virtualbox-ose-additions/pkg-message
@@ -1,7 +1,7 @@
 [
 { type: install
   message: <<EOM
-Oracleⓡ VirtualBoxⓡ Guest Additions are installed.
+VirtualBox Guest Additions are installed.
 
 To enable and start the required services: 
 

--- a/emulators/virtualbox-ose-additions/pkg-message
+++ b/emulators/virtualbox-ose-additions/pkg-message
@@ -5,12 +5,12 @@ VirtualBox Guest Additions are installed.
 
 To enable and start the required services: 
 
-# sysrc vboxguest_enable="YES" ; sync ; service vboxguest start
-# sysrc vboxservice_enable="YES" ; service vboxservice start
+# sysrc vboxguest_enable="YES"
+# sysrc vboxservice_enable="YES"
 
-The vboxguest service will load a required kernel module. If a 
-kernel panic (system crash) occurs, this may be avoided by 
-limiting the FreeBSD guest to one CPU. 
+To start the services, restart the system. If a kernel panic (system crash) 
+occurs during startup, this may be avoided by limiting the FreeBSD guest to 
+one CPU. 
 
 For features such as window scaling and clipboard sharing, membership of 
 the wheel group is required. With username jerry as an example: 

--- a/emulators/virtualbox-ose-additions/pkg-message
+++ b/emulators/virtualbox-ose-additions/pkg-message
@@ -1,23 +1,35 @@
 [
 { type: install
   message: <<EOM
-VirtualBox Guest Additions were installed.
+Oracleⓡ VirtualBoxⓡ Guest Additions are installed.
 
+To enable and start the required services: 
 
-You need to enable the vboxguest startscript to load the kernel module and
-vboxservice to use host time synchronization.
+# sysrc vboxguest_enable="YES" && service vboxguest start
+# sysrc vboxservice_enable="YES" && service vboxservice start
 
-vboxguest_enable="YES"
-vboxservice_enable="YES"
+The vboxguest service will load a required kernel module. If a 
+kernel panic (system crash) occurs, this may be avoided by 
+limiting the FreeBSD guest to one CPU. 
 
-You also have to add all X11 users that want to use any of the additional
-features (clipboard sharing, window scaling) to the wheel group.
+For features such as window scaling and clipboard sharing, membership of 
+the wheel group is required. With username jerry as an example: 
 
-% pw groupmod wheel -m jerry
+# pw groupmod wheel -m jerry
 
-Reboot the machine to load the needed kernel modules.
+The settings dialogue for FreeBSD guests encourages use of the VMSVGA 
+graphics controller. Whilst this might suit installations of FreeBSD 
+without a desktop environment (a common use case), it is not appropriate 
+where Guest Additions are installed. 
 
-For detailed informations please visit http://wiki.freebsd.org/VirtualBox
+Where Guest Additions are installed: 
+
+1. prefer VBoxSVGA
+
+2. do not enable 3D acceleration (doing so will invisibly 
+   lose the preference for VBoxSVGA)
+
+– you may ignore the yellow alert that encourages use of VMSVGA.
 EOM
 }
 ]

--- a/emulators/virtualbox-ose-additions/pkg-message
+++ b/emulators/virtualbox-ose-additions/pkg-message
@@ -5,8 +5,8 @@ Oracleⓡ VirtualBoxⓡ Guest Additions are installed.
 
 To enable and start the required services: 
 
-# sysrc vboxguest_enable="YES" && service vboxguest start
-# sysrc vboxservice_enable="YES" && service vboxservice start
+# sysrc vboxguest_enable="YES" ; sync ; service vboxguest start
+# sysrc vboxservice_enable="YES" ; service vboxservice start
 
 The vboxguest service will load a required kernel module. If a 
 kernel panic (system crash) occurs, this may be avoided by 

--- a/emulators/virtualbox-ose-additions/pkg-message
+++ b/emulators/virtualbox-ose-additions/pkg-message
@@ -8,9 +8,10 @@ To enable and start the required services:
 # sysrc vboxguest_enable="YES"
 # sysrc vboxservice_enable="YES"
 
-To start the services, restart the system. If a kernel panic (system crash) 
-occurs during startup, this may be avoided by limiting the FreeBSD guest to 
-one CPU. 
+To start the services, restart the system. 
+
+In some situations, a panic will occur when the kernel module loads. 
+Having no more than one virtual CPU might mitigate the issue.
 
 For features such as window scaling and clipboard sharing, membership of 
 the wheel group is required. With username jerry as an example: 

--- a/emulators/virtualbox-ose-legacy/pkg-descr
+++ b/emulators/virtualbox-ose-legacy/pkg-descr
@@ -1,4 +1,4 @@
-Oracleⓡ VirtualBoxⓡ is a family of powerful x86 virtualization products 
+Oracle VirtualBox is a family of powerful x86 virtualization products 
 for enterprise as well as home use. Not only is VirtualBox an extremely
 feature rich, high performance product for enterprise customers, it
 is also the only professional solution that is freely available as

--- a/emulators/virtualbox-ose-legacy/pkg-descr
+++ b/emulators/virtualbox-ose-legacy/pkg-descr
@@ -1,7 +1,15 @@
-VirtualBox is a family of powerful x86 virtualization products for
-enterprise as well as home use. Not only is VirtualBox an extremely
+Oracleⓡ VirtualBoxⓡ is a family of powerful x86 virtualization products 
+for enterprise as well as home use. Not only is VirtualBox an extremely
 feature rich, high performance product for enterprise customers, it
 is also the only professional solution that is freely available as
 Open Source Software under the terms of the GNU General Public License.
+
+Non-legacy i.e. emulators/virtualbox-ose is recommended for most use cases. 
+
+Where legacy (5.2.x) is a requirement, this FreeBSD-provided package 
+can be installed in the FreeBSD host machine. 
+
+<https://www.virtualbox.org/wiki/Changelog-5.2> emphasises that 
+5.2.x is no longer supported by Oracle.
 
 WWW: https://www.virtualbox.org/

--- a/emulators/virtualbox-ose-legacy/pkg-descr
+++ b/emulators/virtualbox-ose-legacy/pkg-descr
@@ -1,15 +1,19 @@
-Oracle VirtualBox is a family of powerful x86 virtualization products 
-for enterprise as well as home use. Not only is VirtualBox an extremely
-feature rich, high performance product for enterprise customers, it
-is also the only professional solution that is freely available as
-Open Source Software under the terms of the GNU General Public License.
+Oracle VM VirtualBox is a hosted hypervisor for x86 virtualisation. 
+Supported guests include BSD, Haiku, Linux, OS/2, ReactOS, Solaris and 
+Windows. 
 
-Non-legacy i.e. emulators/virtualbox-ose is recommended for most use cases. 
+emulators/virtualbox-ose is recommended for most use cases. 
 
-Where legacy (5.2.x) is a requirement, this FreeBSD-provided package 
-can be installed in the FreeBSD host machine. 
+emulators/virtualbox-ose-legacy is for exceptional legacy (5.2.x) cases. 
 
 <https://www.virtualbox.org/wiki/Changelog-5.2> emphasises that 
 5.2.x is no longer supported by Oracle.
+
+Guest Additions are available: 
+
+    emulators/virtualbox-ose-additions-legacy
+
+For the Extension Pack: FreeBSD is not a supported host platform. 
+Installation of the Pack will not extend the feature set. 
 
 WWW: https://www.virtualbox.org/

--- a/emulators/virtualbox-ose/pkg-descr
+++ b/emulators/virtualbox-ose/pkg-descr
@@ -1,7 +1,12 @@
-VirtualBox is a family of powerful x86 virtualization products for
-enterprise as well as home use. Not only is VirtualBox an extremely
-feature rich, high performance product for enterprise customers, it
-is also the only professional solution that is freely available as
-Open Source Software under the terms of the GNU General Public License.
+Oracle VM VirtualBox is a hosted hypervisor for x86 virtualisation. 
+Supported guests include BSD, Haiku, Linux, OS/2, ReactOS, Solaris and 
+Windows. 
+
+Guest Additions are available: 
+
+    emulators/virtualbox-ose-additions
+
+For the Extension Pack: FreeBSD is not a supported host platform. 
+Installation of the Pack will not extend the feature set. 
 
 WWW: https://www.virtualbox.org/


### PR DESCRIPTION
Package messages are more focused on: 

* what's recommended and/or required
* how to avoid system crashes of guests with non-legacy additions.

(Whilst it's possible for the same crash to occur with legacy additions, incidents may be so rare that it's not worth mentioning in the package message. The bug can be found through a click on the bug icon at FreshPorts.)

Package messages are more specific. 

Package messages no longer refer to <https://wiki.freebsd.org/VirtualBox>. There's not much of substance in the wiki – users might as easily find the page through, for example, attention to the FreeBSD Handbook. 

Draft; comments and corrections are invited. Thank you. 