### PR TITLE
Updated net/p5-Net-Amazon-S3 from 0.98 to 0.99.

### DIFF
--- a/net/p5-Net-Amazon-S3/Makefile
+++ b/net/p5-Net-Amazon-S3/Makefile
@@ -1,7 +1,7 @@
 # Created by: Gea-Suan Lin <gslin@gslin.org>
 
 PORTNAME=	Net-Amazon-S3
-PORTVERSION=	0.98
+PORTVERSION=	0.99
 CATEGORIES=	net perl5
 MASTER_SITES=	CPAN
 PKGNAMEPREFIX=	p5-

--- a/net/p5-Net-Amazon-S3/distinfo
+++ b/net/p5-Net-Amazon-S3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1622214066
-SHA256 (Net-Amazon-S3-0.98.tar.gz) = 3be9d9af93cd15cf5f2f77bda0a783a9fbcc1d8199c3307b38e90b92a3045c9d
-SIZE (Net-Amazon-S3-0.98.tar.gz) = 131669
+TIMESTAMP = 1640100624
+SHA256 (Net-Amazon-S3-0.99.tar.gz) = 169d5efcf9ad642ad4e599cfc26ca5e5604286484685a0eeb578469894eab91f
+SIZE (Net-Amazon-S3-0.99.tar.gz) = 133057


### PR DESCRIPTION
Regular version bump, fixed some minor upstream issues;
CPAN's tests show FreeBSD versions all in green for this
version of the module.

Please advise if this is not the proper way to update a port such as this.