### PR TITLE
databases/influxdb: improve syslog logging title, remove trailing spaces in rc script

### DIFF
--- a/databases/influxdb/files/influxd.in
+++ b/databases/influxdb/files/influxd.in
@@ -43,25 +43,25 @@ influxd_pidfile="%%INFLUXD_PIDDIR%%${name}.pid"
 procname="%%PREFIX%%/bin/${name}"
 command=/usr/sbin/daemon
 start_precmd="influxd_precmd"
-start_cmd="influxd_startcmd_%%INFLUXD_LOGCMD%%"        
+start_cmd="influxd_startcmd_%%INFLUXD_LOGCMD%%"
 
 influxd_precmd()
 {
     install -d -o ${influxd_user} %%INFLUXD_PIDDIR%%
 }
 
-influxd_startcmd_daemon()                      
-{   
-    echo "Starting ${name}."                   
+influxd_startcmd_daemon()
+{
+    echo "Starting ${name}."
     /usr/sbin/daemon -c -p ${influxd_pidfile} -S -s ${influxd_priority} -l ${influxd_facility} -T ${name} \
         -u ${influxd_user} ${procname} ${influxd_options}
-}                                              
+}
 
-influxd_startcmd_logger()                      
-{   
-    echo "Starting ${name}."                   
+influxd_startcmd_logger()
+{
+    echo "Starting ${name}."
     /usr/sbin/daemon -c -p ${influxd_pidfile} -u ${influxd_user} /bin/sh -c "${procname} ${influxd_options} 2>&1 \
         | /usr/bin/logger -t ${name} -p ${influxd_facility}.${influxd_priority}"
-}                                              
+}
 
 run_rc_command "$1"

--- a/databases/influxdb/files/influxd.in
+++ b/databases/influxdb/files/influxd.in
@@ -53,7 +53,7 @@ influxd_precmd()
 influxd_startcmd_daemon()                      
 {   
     echo "Starting ${name}."                   
-    /usr/sbin/daemon -c -p ${influxd_pidfile} -S -s ${influxd_priority} -l ${influxd_facility} \
+    /usr/sbin/daemon -c -p ${influxd_pidfile} -S -s ${influxd_priority} -l ${influxd_facility} -T ${name} \
         -u ${influxd_user} ${procname} ${influxd_options}
 }                                              
 


### PR DESCRIPTION
Currently, logging messages from influxd (which go through syslog) are logged as coming from `daemon` rather thant influxd itself.  Example:

> Jan 13 02:08:13 icarus daemon[43241]: ts=2022-01-13T10:08:13.768315Z lvl=info msg="InfluxDB starting" log_id=0Z0jOen0000 version=1.8.9 branch=unknown commit=unknown

This makes it impossible to filter said messages to a separate file via syslog.conf'd `!programname` feature.  And changing the facility to something like local7 is not sufficient either, as there are many programs which could use that facility as well.

This PR uses the `-T` flag of `daemon` to specify the process name, which alleviates this problem.  Example:

> Jan 13 02:09:10 icarus influxd[43292]: ts=2022-01-13T10:09:10.424810Z lvl=info msg="InfluxDB starting" log_id=0Z0jS760000 version=1.8.9 branch=unknown commit=unknown`

Thus, we can now successfully use a syslog.conf rule like the below to shove all influxdb messages into a separate file:

```
!influxd
*.*             /var/log/influxd.log
!*
```

Finally, this PR also removes a whole slew of trailing spaces from the rc script.