### PR TITLE
multimedia/snapcast No longer broken after upgrade to 0.26.0

### DIFF
--- a/multimedia/snapcast/Makefile
+++ b/multimedia/snapcast/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	snapcast
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.25.0
+DISTVERSION=	0.26.0
 CATEGORIES=	multimedia audio
 
 MAINTAINER=	yuri@FreeBSD.org
@@ -17,8 +17,6 @@ LIB_DEPENDS=	libavahi-common.so:net/avahi-app \
 		libopus.so:audio/opus \
 		libvorbis.so:audio/libvorbis \
 		libsoxr.so:audio/libsoxr
-
-BROKEN=		error: non-constant-expression cannot be narrowed from type 'unsigned long' to 'int' in initializer list 
 
 USES=		cmake compiler:c++14-lang pkgconfig
 

--- a/multimedia/snapcast/distinfo
+++ b/multimedia/snapcast/distinfo
@@ -1,3 +1,3 @@
 TIMESTAMP = 1621177575
-SHA256 (badaix-snapcast-v0.25.0_GH0.tar.gz) = c4e449cb693e091261727421f4965492be049632537e034fa9c59c92d091a846
-SIZE (badaix-snapcast-v0.25.0_GH0.tar.gz) = 1412827
+SHA256 (badaix-snapcast-v0.26.0_GH0.tar.gz) = 166353267a5c461a3a0e7cbd05d78c4bfdaebeda078801df3b76820b54f27683
+SIZE (badaix-snapcast-v0.25.0_GH0.tar.gz) = 1537036


### PR DESCRIPTION
Upgrade to 0.26.0 and unbreak