### PR TITLE
Fix typo in rsync

### DIFF
--- a/sysutils/dirvish/pkg-descr
+++ b/sysutils/dirvish/pkg-descr
@@ -1,4 +1,4 @@
-This is a network-based backup system based of rync.  It can do full and
+This is a network-based backup system based of rsync.  It can do full and
 incremental backups to a remote file server.  It relies on rsync for the
 host to host copy and uses hard links to provide multiple snapshots of the
 data without duplicating identical files.


### PR DESCRIPTION
Correct typo in package description file.
