### PR TITLE
Add support to build ports as PIE executables. 

### DIFF
--- a/Mk/Features/pie.mk
+++ b/Mk/Features/pie.mk
@@ -1,0 +1,14 @@
+# PIE Support
+
+.if !defined(_PIE_MK_INCLUDED)
+_PIE_MK_INCLUDED=	yes
+PIE_Include_MAINTAINER=	portmgr@FreeBSD.org
+
+.  if !defined(PIE_UNSAFE)
+PIE_CFLAGS?=	-fPIE -fPIC
+CFLAGS+=	${PIE_CFLAGS}
+CXXFLAGS+=	${PIE_CFLAGS}
+LDFLAGS+=	-pie
+.  endif
+.endif
+

--- a/Mk/Uses/go.mk
+++ b/Mk/Uses/go.mk
@@ -90,7 +90,12 @@ GO_PKGNAME=	${PORTNAME}
 GO_TARGET?=	${GO_PKGNAME}
 GO_TESTTARGET?=	./...
 
-GO_BUILDFLAGS+=	-v -buildmode=exe -trimpath
+.if !defined(PIE_UNSAFE)
+GO_BUILDFLAGS+= -buildmode=pie
+.else
+GO_BUILDFLAGS+= -buildmode=exe
+.endif
+GO_BUILDFLAGS+= -v -trimpath
 .  if !defined(WITH_DEBUG) && empty(GO_BUILDFLAGS:M-ldflags*)
 GO_BUILDFLAGS+=	-ldflags=-s
 .  endif

--- a/Mk/bsd.port.mk
+++ b/Mk/bsd.port.mk
@@ -339,6 +339,11 @@ FreeBSD_MAINTAINER=	portmgr@FreeBSD.org
 #				  can be used in Makefiles by port maintainers
 #				  if a port breaks with it (it should be
 #				  extremely rare).
+# PIE_CFLAGS	- Defaults to -fPIE -fPIC. This value
+#				  is added to CFLAGS and the necessary flags
+#				  are added to LDFLAGS. Note that PIE_UNSAFE
+#				  can be used in Makefiles by port maintainers
+#				  if a port breaks with it.
 ##
 # USE_LOCALE	- LANG and LC_ALL are set to the value of this variable in
 #				  CONFIGURE_ENV and MAKE_ENV.  Example: USE_LOCALE=en_US.UTF-8
@@ -1012,7 +1017,7 @@ LC_ALL=		C
 # These need to be absolute since we don't know how deep in the ports
 # tree we are and thus can't go relative.  They can, of course, be overridden
 # by individual Makefiles or local system make configuration.
-_LIST_OF_WITH_FEATURES=	debug lto ssp
+_LIST_OF_WITH_FEATURES=	debug lto ssp pie
 _DEFAULT_WITH_FEATURES=	ssp
 PORTSDIR?=		/usr/ports
 LOCALBASE?=		/usr/local
@@ -1772,8 +1777,6 @@ CFLAGS:=	${CFLAGS:C/${_CPUCFLAGS}//}
 .      endif
 .    endfor
 
-# XXX PIE support to be added here
-MAKE_ENV+=	NO_PIE=yes
 # We will control debug files.  Don't let builds that use /usr/share/mk
 # split out debug symbols since the plist won't know to expect it.
 MAKE_ENV+=	MK_DEBUG_FILES=no


### PR DESCRIPTION
Extend the current mechanism to provide an option for the ports to compile as PIE executable.
This will allow utilization of ASLR provided by the kernel and improves the cost of the attacker to do control flow hijacking of services.

Sponsored by:Netflix