### PR TITLE
drm-kmod: package description: correct and update

### DIFF
--- a/graphics/drm-kmod/pkg-descr
+++ b/graphics/drm-kmod/pkg-descr
@@ -1,11 +1,13 @@
-amdgpu, i915, and radeon DRM modules for the linuxkpi-based KMS components on
-amd64, i915 and radeonkms DRM modules from the former base DRM component on
-other architectures.
-Metaport for different versions of Linux DRM based on the FreeBSD version
-in use. This port encompasses the recommendations of the FreeBSDDesktop team
-of DRM versions for FreeBSD versions based on the last update to the LinuxKPI
-in that code base. In general, the most recent supported stable DRM for a give
-FreeBSD version will be installed. CURRENT receives the most recent development
-DRM.
-This port does not however hinder the expert user to make other decisions and
-continue to install DRM ports directly.
+Direct Rendering Manager (DRM) modules for LinuxKPI-based kernel mode setting 
+(KMS) components. Modules for amdgpu, i915, and radeon (based on amd64, i915 
+and radeonkms modules from the former base DRM component on other 
+architectures). This metaport encompasses recommended versions of DRM, based 
+on the most recent updates to the LinuxKPI in specific versions of FreeBSD. 
+Generally, the main branch (CURRENT) receives the most recent development DRM.
+
+Installing this metaport will: 
+
+* additionally, install the port of the most recent supported stable modules 
+  for the running version of FreeBSD 
+
+* not hinder expert approaches such as direct installation of DRM ports.


### PR DESCRIPTION
Correct a typo (given, not give). 

Whilst here: aim to make the description more understandable to readers who may be new to, or relatively unfamiliar, with things such as DRM. In particular: 

* make clearer that modules are in a separate port (not this metaport).