### PR TITLE
add Homebridge as uid 866

### DIFF
--- a/UIDs
+++ b/UIDs
@@ -812,7 +812,7 @@ opensearch:*:855:855::0:0:opensearch user:/nonexistent:/usr/sbin/nologin
 # free: 863
 # free: 864
 # free: 865
-# free: 866
+homebridge:*:866:866::0:0:Homebridge user:/nonexistent:/usr/sbin/nologin
 # free: 867
 # free: 868
 keyd:*:869:869::0:0:Key remapping daemon for evdev:/nonexistent:/usr/sbin/nologin


### PR DESCRIPTION
Pretty happily running [Homebridge](https://github.com/homebridge/homebridge) in an iocage-based jail. Homebridge accepted my patches for FreeBSD support last year and install instructions are like [this](https://gist.github.com/ohmantics/11516438b693a91e8bca4edcba7f796b).