### PR TITLE
multimedia/emby-server(-devel): pass -P to daemon(8)

### DIFF
--- a/multimedia/emby-server-devel/Makefile
+++ b/multimedia/emby-server-devel/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	emby-server
 DISTVERSION=	4.8.0.21
+PORTREVISION=	1
 CATEGORIES=	multimedia
 MASTER_SITES=	https://github.com/MediaBrowser/Emby.Releases/releases/download/${DISTVERSION}/ \
 		https://mediabrowser.github.io/embytools/

--- a/multimedia/emby-server-devel/files/emby-server.in
+++ b/multimedia/emby-server-devel/files/emby-server.in
@@ -46,7 +46,7 @@ load_rc_config ${name}
 pidfile="${%%RC_NAME%%_pid}"
 procname="%%PREFIX%%/lib/emby-server/system/EmbyServer"
 command="/usr/sbin/daemon"
-command_args="-r -f -p ${%%RC_NAME%%_pid} ${procname} \
+command_args="-r -f -P ${%%RC_NAME%%_pid} ${procname} \
 	-os freebsd \
 	-ffdetect ${%%RC_NAME%%_ffdetect} \
 	-ffmpeg ${%%RC_NAME%%_ffmpeg} \

--- a/multimedia/emby-server/Makefile
+++ b/multimedia/emby-server/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	emby-server
 DISTVERSION=	4.7.11.0
+PORTREVISION=	1
 CATEGORIES=	multimedia
 MASTER_SITES=	https://github.com/MediaBrowser/Emby.Releases/releases/download/${DISTVERSION}/ \
 		https://mediabrowser.github.io/embytools/

--- a/multimedia/emby-server/files/emby-server.in
+++ b/multimedia/emby-server/files/emby-server.in
@@ -46,7 +46,7 @@ load_rc_config ${name}
 pidfile="${%%RC_NAME%%_pid}"
 procname="%%PREFIX%%/lib/emby-server/system/EmbyServer"
 command="/usr/sbin/daemon"
-command_args="-r -f -p ${%%RC_NAME%%_pid} ${procname} \
+command_args="-r -f -P ${%%RC_NAME%%_pid} ${procname} \
 	-os freebsd \
 	-ffdetect ${%%RC_NAME%%_ffdetect} \
 	-ffmpeg ${%%RC_NAME%%_ffmpeg} \


### PR DESCRIPTION
With the -r option, the -P option must be used instead of the -p option. Otherwise, when stopping the service, daemon will restart the child. See man daemon(8).