### PR TITLE
Update website URL and license for py-rope

### DIFF
--- a/devel/py-rope/Makefile
+++ b/devel/py-rope/Makefile
@@ -6,9 +6,9 @@ PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
 MAINTAINER=	jjachuf@gmail.com
 COMMENT=	Python refactoring library
-WWW=		http://rope.sourceforge.net
+WWW=		https://github.com/python-rope/rope/
 
-LICENSE=	GPLv2
+LICENSE=	LGPL3
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		cpe python:3.6+


### PR DESCRIPTION
Hi, I am the maintainer of python-rope, just updating this outdated metadata here.

Rope has moved from Sourceforge to GitHub and has [relicensed to LGPLv3+](https://github.com/python-rope/rope/issues/262).

Also noted that rope 0.18.0 is severely out of date, the latest version of rope is 1.7.0. I don't use BSD, so I can't really test it on this OS, so I am leaving them as it is; but if anyone is actually interested in installing this package from BSD Ports, it would be appreciated to update the version here as well.