### PR TITLE
multimedia/emby-server(-devel): remove redundant pid operations

### DIFF
--- a/multimedia/emby-server-devel/Makefile
+++ b/multimedia/emby-server-devel/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	emby-server
 DISTVERSION=	4.8.0.21
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	multimedia
 MASTER_SITES=	https://github.com/MediaBrowser/Emby.Releases/releases/download/${DISTVERSION}/ \
 		https://mediabrowser.github.io/embytools/

--- a/multimedia/emby-server-devel/files/emby-server.in
+++ b/multimedia/emby-server-devel/files/emby-server.in
@@ -55,8 +55,7 @@ command_args="-r -f -P ${%%RC_NAME%%_pid} %%PREFIX%%/lib/emby-server/system/Emby
 start_precmd=%%RC_NAME%%_precmd
 %%RC_NAME%%_precmd()
 {
-	[ -f ${%%RC_NAME%%_pid} ] || install -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} -- /dev/null ${%%RC_NAME%%_pid}
-	[ -d ${%%RC_NAME%%_data_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} -- ${%%RC_NAME%%_data_dir}
+	[ -d ${%%RC_NAME%%_data_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} ${%%RC_NAME%%_data_dir}
 
 	# .NET 6+ use dual mode sockets to avoid the separate AF handling.
 	# disable .NET use of V6 if no ipv6 is configured.
@@ -67,12 +66,6 @@ start_precmd=%%RC_NAME%%_precmd
 	fi
 
 	export LD_LIBRARY_PATH=%%PREFIX%%/lib/emby-server/lib:%%LOCALBASE%%/lib
-}
-
-stop_postcmd=%%RC_NAME%%_postcmd
-%%RC_NAME%%_postcmd()
-{
-	rm -f ${%%RC_NAME%%_pid}
 }
 
 run_rc_command "$1"

--- a/multimedia/emby-server-devel/files/emby-server.in
+++ b/multimedia/emby-server-devel/files/emby-server.in
@@ -26,8 +26,10 @@
 #			Default: %%PREFIX%%/lib/emby-server/bin/ffmpeg
 # %%RC_NAME%%_ffprobe:	Path of the ffprobe binary.
 #			Default: %%PREFIX%%/lib/emby-server/bin/ffprobe
-# %%RC_NAME%%_pid: 	Path of the pid file.
-#			Default: /var/run/%%PORTNAME%%.pid
+# %%RC_NAME%%_pid:	Name of the pid file.
+#			Default: %%PORTNAME%%.pid
+# %%RC_NAME%%_pid_dir:	Path of the pid file.
+#			Default: /var/run/emby-server
 
 . /etc/rc.subr
 name=%%RC_NAME%%
@@ -41,20 +43,22 @@ load_rc_config ${name}
 : ${%%RC_NAME%%_ffdetect:="%%PREFIX%%/lib/emby-server/bin/ffdetect"}
 : ${%%RC_NAME%%_ffmpeg:="%%PREFIX%%/lib/emby-server/bin/ffmpeg"}
 : ${%%RC_NAME%%_ffprobe:="%%PREFIX%%/lib/emby-server/bin/ffprobe"}
-: ${%%RC_NAME%%_pid:="/var/run/%%PORTNAME%%.pid"}
+: ${%%RC_NAME%%_pid:="%%PORTNAME%%.pid"}
+: ${%%RC_NAME%%_pid_dir:="/var/run/emby-server"}
 
-pidfile="${%%RC_NAME%%_pid}"
+pidfile="${%%RC_NAME%%_pid_dir}/${%%RC_NAME%%_pid}"
 command="/usr/sbin/daemon"
-command_args="-r -f -P ${%%RC_NAME%%_pid} %%PREFIX%%/lib/emby-server/system/EmbyServer \
+command_args="-r -f -P ${pidfile} %%PREFIX%%/lib/emby-server/system/EmbyServer \
 	-os freebsd \
 	-ffdetect ${%%RC_NAME%%_ffdetect} \
 	-ffmpeg ${%%RC_NAME%%_ffmpeg} \
 	-ffprobe ${%%RC_NAME%%_ffprobe} \
 	-programdata ${%%RC_NAME%%_data_dir}"
 
-start_precmd=%%RC_NAME%%_precmd
-%%RC_NAME%%_precmd()
+start_precmd=%%RC_NAME%%_start_precmd
+%%RC_NAME%%_start_precmd()
 {
+	[ -d ${%%RC_NAME%%_pid_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} ${%%RC_NAME%%_pid_dir}
 	[ -d ${%%RC_NAME%%_data_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} ${%%RC_NAME%%_data_dir}
 
 	# .NET 6+ use dual mode sockets to avoid the separate AF handling.

--- a/multimedia/emby-server/Makefile
+++ b/multimedia/emby-server/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	emby-server
 DISTVERSION=	4.7.11.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	multimedia
 MASTER_SITES=	https://github.com/MediaBrowser/Emby.Releases/releases/download/${DISTVERSION}/ \
 		https://mediabrowser.github.io/embytools/

--- a/multimedia/emby-server/files/emby-server.in
+++ b/multimedia/emby-server/files/emby-server.in
@@ -55,8 +55,7 @@ command_args="-r -f -P ${%%RC_NAME%%_pid} %%PREFIX%%/lib/emby-server/system/Emby
 start_precmd=%%RC_NAME%%_precmd
 %%RC_NAME%%_precmd()
 {
-	[ -f ${%%RC_NAME%%_pid} ] || install -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} -- /dev/null ${%%RC_NAME%%_pid}
-	[ -d ${%%RC_NAME%%_data_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} -- ${%%RC_NAME%%_data_dir}
+	[ -d ${%%RC_NAME%%_data_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} ${%%RC_NAME%%_data_dir}
 
 	# .NET 6+ use dual mode sockets to avoid the separate AF handling.
 	# disable .NET use of V6 if no ipv6 is configured.
@@ -67,12 +66,6 @@ start_precmd=%%RC_NAME%%_precmd
 	fi
 
 	export LD_LIBRARY_PATH=%%PREFIX%%/lib/emby-server/lib:%%LOCALBASE%%/lib
-}
-
-stop_postcmd=%%RC_NAME%%_postcmd
-%%RC_NAME%%_postcmd()
-{
-	rm -f ${%%RC_NAME%%_pid}
 }
 
 run_rc_command "$1"

--- a/multimedia/emby-server/files/emby-server.in
+++ b/multimedia/emby-server/files/emby-server.in
@@ -26,8 +26,10 @@
 #			Default: %%PREFIX%%/lib/emby-server/bin/ffmpeg
 # %%RC_NAME%%_ffprobe:	Path of the ffprobe binary.
 #			Default: %%PREFIX%%/lib/emby-server/bin/ffprobe
-# %%RC_NAME%%_pid: 	Path of the pid file.
-#			Default: /var/run/%%PORTNAME%%.pid
+# %%RC_NAME%%_pid:	Name of the pid file.
+#			Default: %%PORTNAME%%.pid
+# %%RC_NAME%%_pid_dir:	Path of the pid file.
+#			Default: /var/run/emby-server
 
 . /etc/rc.subr
 name=%%RC_NAME%%
@@ -41,20 +43,22 @@ load_rc_config ${name}
 : ${%%RC_NAME%%_ffdetect:="%%PREFIX%%/lib/emby-server/bin/ffdetect"}
 : ${%%RC_NAME%%_ffmpeg:="%%PREFIX%%/lib/emby-server/bin/ffmpeg"}
 : ${%%RC_NAME%%_ffprobe:="%%PREFIX%%/lib/emby-server/bin/ffprobe"}
-: ${%%RC_NAME%%_pid:="/var/run/%%PORTNAME%%.pid"}
+: ${%%RC_NAME%%_pid:="%%PORTNAME%%.pid"}
+: ${%%RC_NAME%%_pid_dir:="/var/run/emby-server"}
 
-pidfile="${%%RC_NAME%%_pid}"
+pidfile="${%%RC_NAME%%_pid_dir}/${%%RC_NAME%%_pid}"
 command="/usr/sbin/daemon"
-command_args="-r -f -P ${%%RC_NAME%%_pid} %%PREFIX%%/lib/emby-server/system/EmbyServer \
+command_args="-r -f -P ${pidfile} %%PREFIX%%/lib/emby-server/system/EmbyServer \
 	-os freebsd \
 	-ffdetect ${%%RC_NAME%%_ffdetect} \
 	-ffmpeg ${%%RC_NAME%%_ffmpeg} \
 	-ffprobe ${%%RC_NAME%%_ffprobe} \
 	-programdata ${%%RC_NAME%%_data_dir}"
 
-start_precmd=%%RC_NAME%%_precmd
-%%RC_NAME%%_precmd()
+start_precmd=%%RC_NAME%%_start_precmd
+%%RC_NAME%%_start_precmd()
 {
+	[ -d ${%%RC_NAME%%_pid_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} ${%%RC_NAME%%_pid_dir}
 	[ -d ${%%RC_NAME%%_data_dir} ] || install -d -g ${%%RC_NAME%%_group} -o ${%%RC_NAME%%_user} ${%%RC_NAME%%_data_dir}
 
 	# .NET 6+ use dual mode sockets to avoid the separate AF handling.


### PR DESCRIPTION
@driesmp 

Something still to note here:
The rc.subr automatically creates and removes the pid file.   "-- /dev/null" in the install hides that there is an error creating a file that already exists.