### PR TITLE
benchmarks/fio: Update WWW

### DIFF
--- a/benchmarks/fio/Makefile
+++ b/benchmarks/fio/Makefile
@@ -5,7 +5,7 @@ MASTER_SITES=	https://brick.kernel.dk/snaps/
 
 MAINTAINER=	krion@FreeBSD.org
 COMMENT=	Flexible IO tester
-WWW=		https://git.kernel.dk/?p=fio.git
+WWW=		https://git.kernel.dk/cgit/fio/
 
 LICENSE=	GPLv2
 LICENSE_FILE=	${WRKSRC}/COPYING


### PR DESCRIPTION
Use the canonical URL described in https://git.kernel.dk/cgit/fio/tree/README.rst