### PR TITLE
net-im/ejabberd: Small fixes

### DIFF
--- a/net-im/ejabberd/Makefile
+++ b/net-im/ejabberd/Makefile
@@ -1,10 +1,10 @@
 PORTNAME=	ejabberd
 PORTVERSION=	23.01
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net-im
 
 MAINTAINER=	ashish@FreeBSD.org
-COMMENT=	Free and Open Source distributed fault-tolerant Jabber server
+COMMENT=	Free and Open Source distributed fault-tolerant XMPP server
 WWW=		https://www.ejabberd.im/
 
 LICENSE=	GPLv2
@@ -55,7 +55,7 @@ GH_TUPLE=	processone:p1_utils:${P1_UTILS_VER}:p1_utils/deps/p1_utils \
 
 OPTIONS_DEFINE=	ODBC PAM DOCS LUA MYSQL PGSQL REDIS SIP SQLITE \
 		STUN TOOLS FULLXML
-OPTIONS_DEFAULT=STUN
+OPTIONS_DEFAULT=SQLITE STUN
 
 EJABBERD_LIBDIR=lib/erlang/lib
 MAKE_ENV=	PORTVERSION=${PORTVERSION}

--- a/net-im/ejabberd/files/ejabberd.in
+++ b/net-im/ejabberd/files/ejabberd.in
@@ -68,7 +68,7 @@ ejabberd_reload()
 {
     echo "Restarting $name."
     if ejabberd_checkstatus; then
-        su $EJABBERDUSER -c "env ERL_EPMD_ADDRESS=\"${ejabberd_epmd_address}\" $EJABBERDCTL --node $ejabberd_node restart"
+        su $EJABBERDUSER -c "env ERL_EPMD_ADDRESS=\"${ejabberd_epmd_address}\" $EJABBERDCTL --node $ejabberd_node reload_config"
     else
         ejabberd_start
     fi


### PR DESCRIPTION
- Updated description to say XMPP
- Build in SQLite by default
- Use reload_config for reload command as ejabberd natively supports hot-reloading configurations