### PR TITLE
www/nginx: start only with nginx_checkconfig success

### DIFF
--- a/www/nginx/files/nginx.in
+++ b/www/nginx/files/nginx.in
@@ -140,7 +140,7 @@ nginx_prestart()
 		required_modules="$required_modules accf_http accf_data"
 	fi
 
-	nginx_checkconfig
+	nginx_checkconfig || return 1
 
 	if checkyesno nginxlimits_enable
 	then


### PR DESCRIPTION
Hi!
Is it intentionall that `nginx_prestart()` ignores the `nginx_checkconfig` result?
So it is possible that nginx will try to start with a known broken config? (which can lead, for example, to the prevention of subsequent starts if the `listen` socket is not deleted on failed startup).
Thanks!