### PR TITLE
net-mgmt/unbound_exporter: fix typos in rc.d script

### DIFF
--- a/net-mgmt/unbound_exporter/files/unbound_exporter.in
+++ b/net-mgmt/unbound_exporter/files/unbound_exporter.in
@@ -44,8 +44,8 @@ command_args="-c -f -P ${pidfile} -u ${unbound_exporter_user} \
 	${unbound_exporter_cert:+-unbound.cert $unbound_exporter_cert} \
 	${unbound_exporter_host:+-unbound.host $unbound_exporter_host} \
 	${unbound_exporter_key:+-unbound.key $unbound_exporter_key} \
-	${unbound_exporter_bind:+-web.listen-adress $unbound_exporter_bin}
-	${unbound_exporter_path:+-web.telemetry-patch $unbound_exporter_path}
+	${unbound_exporter_bind:+-web.listen-address $unbound_exporter_bind} \
+	${unbound_exporter_path:+-web.telemetry-path $unbound_exporter_path} \
 	${unbound_exporter_args}"
 
 # these were used in the past, but now "daemon" takes care of everything and must run as root


### PR DESCRIPTION
There are typos in two arguments to unbound_exporter within its service script. This fixes typos in the unbound_exporter_bind and unbound_exporter_path variables application to unbound_exporter startup.

They prevent successful startup of unbound_exporter with `service unbound start`. The unbound_exporter process fails to
start due to errors in its command arguments.

This PR addresses those typos. It has been tested on my pfSense appliance.

PS: I am unclear whether this should be submitted here as a PR, or as a patch in another manner somewhere else. If you need
anything changed, just let me now!