### PR TITLE
sysutils/py-mqttwarn: Update documentation

### DIFF
--- a/sysutils/py-mqttwarn/Makefile
+++ b/sysutils/py-mqttwarn/Makefile
@@ -6,7 +6,9 @@ PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
 MAINTAINER=	dvl@FreeBSD.org
 COMMENT=	Subscribe to MQTT topics and notify pluggable services
-WWW=		https://github.com/jpmens/mqttwarn
+WWW=		https://mqttwarn.readthedocs.io/
+			https://github.com/jpmens/mqttwarn
+			https://pypi.org/project/mqttwarn/
 
 LICENSE=	EPL
 

--- a/sysutils/py-mqttwarn/Makefile
+++ b/sysutils/py-mqttwarn/Makefile
@@ -38,7 +38,7 @@ NO_ARCH=	yes
 # The following were omitted because their dependencies are not found in the
 # FreeBSD port tree: AMQP APPRISE ASTERISK FBCHAT IOHUB NMA NSCA OSXNOTIFY PASTEBINPUB PROWL PUSHBULLET
 #                    SLACK TOOTPASTE XIVELY XMPP
-OPTIONS_DEFINE=	APNS CELERY DNSUPDATE DOCS EXAMPLES GSS2 MYSQL POSTGRES REISPUB \
+OPTIONS_DEFINE=	APNS CELERY DNSUPDATE DOCS EXAMPLES GSS2 MYSQL POSTGRES REDISPUB \
 		RRDTOOL SERIAL SSH TWILIO TWITTER WEBSOCKET
 
 USERS=		mqttwarn
@@ -52,7 +52,7 @@ DNSUPDATE_DESC=	DNS updates
 GSS2_DESC=	Google Docs Spreadsheet 2
 MYSQL_DESC=	MySQL plugin
 POSTGRES_DESC=	PostgreSQL Plugin
-REISPUB_DESC=	Publishes to a Redis channel
+REDISPUB_DESC=	Publishes to a Redis channel
 RRDTOOL_DESC=	Updates a round robin database created by rrdtool
 SERIAL_DESC=	Serial port
 SSH_DESC=	ssh plugin
@@ -67,7 +67,7 @@ GSS2_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}gspread>=2.1.10:net/py-gspread@${PY_FLA
 			${PYTHON_PKGNAMEPREFIX}oauth2client>=4.1.2:security/py-oauth2client@${PY_FLAVOR}
 MYSQL_USES=		mysql
 POSTGRES_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}psycopg2>=2.7.4:databases/py-psycopg2@${PY_FLAVOR}
-REISPUB_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}redis>=2.10.6:databases/py-redis@${PY_FLAVOR}
+REDISPUB_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}redis>=2.10.6:databases/py-redis@${PY_FLAVOR}
 RRDTOOL_LIB_DEPENDS=	librrd.so:databases/rrdtool
 RRDTOOL_RUN_DEPENDS=	rrdtool>0.1.12:databases/rrdtool
 SERIAL_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pyserial>3.40:comms/py-pyserial@${PY_FLAVOR}

--- a/sysutils/py-mqttwarn/pkg-descr
+++ b/sysutils/py-mqttwarn/pkg-descr
@@ -1,6 +1,13 @@
-mqttwarn subscribes to any number of MQTT topics (which may include wildcards)
-and publishes received payloads to one or more notification services, including
-support for notifying more than one distinct service for the same message.
+mqttwarn is a highly configurable MQTT message router, where the routing
+targets are notification plugins, primarily written in Python.
 
-For example, you may wish to notify via e-mail and to Pushover of an alarm
-published as text to the MQTT topic home/monitoring/+.
+mqttwarn subscribes to any number of MQTT topics and publishes received
+payloads to one or more notification services after optionally applying
+sophisticated transformations.
+
+It comes with over 70 notification handler plugins covering a wide range
+of notification services, and has an adapter for the Apprise notification
+library, covering another set of 80+ notification services.
+
+Repository: https://github.com/jpmens/mqttwarn
+Documentation: https://mqttwarn.readthedocs.io/


### PR DESCRIPTION
Dear @dlangille,

following up on your recent commit 53fec2142f28f6, and my proposal at https://github.com/jpmens/mqttwarn/issues/646#issuecomment-1528730347, I am submitting this patch in order to slightly update the documentation for `sysutils/py-mqttwarn`. Other than this, it fixes a minor typo on a variable within the package Makefile. Let me know about any adjustments you would like to see.

With kind regards,
Andreas.
