### PR TITLE
www/p5-CGI-Compile: Add devel/p5-Sub-Name to RUN_DEPENDS

### DIFF
--- a/www/p5-CGI-Compile/Makefile
+++ b/www/p5-CGI-Compile/Makefile
@@ -14,7 +14,8 @@ LICENSE_COMB=	dual
 
 BUILD_DEPENDS=	${RUN_DEPENDS}
 RUN_DEPENDS=	\
-	p5-File-pushd>0:devel/p5-File-pushd
+	p5-File-pushd>0:devel/p5-File-pushd \
+	p5-Sub-Name>0:devel/p5-Sub-Name
 TEST_DEPENDS=	\
 	p5-Test-NoWarnings>0:devel/p5-Test-NoWarnings \
 	p5-Test-Requires>0:devel/p5-Test-Requires \


### PR DESCRIPTION
As of version 0.24, CGI::Compile requires Sub::Name package to run. This small patch will fix its Makefile according to the cpanfile.

https://metacpan.org/release/RKITOVER/CGI-Compile-0.25/source/Changes#L6-7
> 0.24  2020-01-30 13:59:56 UTC
>         - use better packages/subnames for coderefs

https://metacpan.org/release/RKITOVER/CGI-Compile-0.25/source/cpanfile#L3
> requires 'Sub::Name';