### PR TITLE
games/melonds: Update to 0.9.5

### DIFF
--- a/games/melonds/Makefile
+++ b/games/melonds/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	melonds
 PORTVERSION=	0.9.5
-PORTREVISION=	0
 CATEGORIES=	games
 PKGNAMESUFFIX=	-${FLAVOR}
 
@@ -19,9 +18,10 @@ FLAVORS=	qt5 qt6
 FLAVOR?=	qt5
 
 USES=		cmake compiler:c++17-lang desktop-file-utils gnome \
-		iconv libarchive pkgconfig qt:${FLAVOR:S/qt//} sdl
+		iconv libarchive pkgconfig qt:${FLAVOR:S/qt//} sdl kde:5
 USE_GNOME=	glib20
 USE_SDL=	sdl2
+USE_KDE=	ecm:build
 
 .if ${FLAVOR} == qt5
 CMAKE_OFF=	USE_QT6

--- a/games/melonds/Makefile
+++ b/games/melonds/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	melonds
-PORTVERSION=	0.9.4
-PORTREVISION=	1
+PORTVERSION=	0.9.5
+PORTREVISION=	0
 CATEGORIES=	games
 PKGNAMESUFFIX=	-${FLAVOR}
 
@@ -13,8 +13,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BROKEN_i386=	static_assert failed due to requirement 'sizeof(TestCase) == 4312'
 
-LIB_DEPENDS=	libslirp.so:net/libslirp \
-		libepoxy.so:graphics/libepoxy
+LIB_DEPENDS=	libslirp.so:net/libslirp
 
 FLAVORS=	qt5 qt6
 FLAVOR?=	qt5
@@ -33,13 +32,13 @@ CMAKE_ON=	USE_QT6
 USE_GITHUB=	yes
 GH_ACCOUNT=	melonDS-emu
 GH_PROJECT=	melonDS
-GH_TAGNAME=	0.9.4
+GH_TAGNAME=	0.9.5
 
 qt5_CONFLICTS_INSTALL=	${PORTNAME}-qt6
 qt6_CONFLICTS_INSTALL=	${PORTNAME}-qt5
 
-_USE_QT5=	core gui network widgets buildtools:build qmake:build
-_USE_QT6=	base
+_USE_QT5=	core gui network widgets multimedia buildtools:build qmake:build
+_USE_QT6=	base multimedia
 USE_QT=		${_USE_QT${FLAVOR:S/qt//}}
 
 .include <bsd.port.mk>

--- a/games/melonds/distinfo
+++ b/games/melonds/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1662945631
-SHA256 (melonDS-emu-melonDS-0.9.4_GH0.tar.gz) = 8022c8798a723f8ffae6ffdad2e7637cf9046e88f86b55b5f9ad3fa3b2e6d398
-SIZE (melonDS-emu-melonDS-0.9.4_GH0.tar.gz) = 2330696
+TIMESTAMP = 1689499885
+SHA256 (melonDS-emu-melonDS-0.9.5_GH0.tar.gz) = 52c6b99340b8bba8c52b11a2242591f05e838c34ddd9ec20dcf1a6039405434a
+SIZE (melonDS-emu-melonDS-0.9.5_GH0.tar.gz) = 2496704

--- a/games/melonds/files/patch-backport-43d091361e
+++ b/games/melonds/files/patch-backport-43d091361e
@@ -1,0 +1,25 @@
+From 43d091361ed6b400a68911147fd5fe524ccecf34 Mon Sep 17 00:00:00 2001
+From: RSDuck <RSDuck@users.noreply.github.com>
+Date: Fri, 25 Nov 2022 23:47:36 +0100
+Subject: [PATCH] fix #1551
+
+---
+ src/frontend/duckstation/duckstation_compat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/frontend/duckstation/duckstation_compat.h src/frontend/duckstation/duckstation_compat.h
+index a661e926..fed37805 100644
+--- src/frontend/duckstation/duckstation_compat.h
++++ src/frontend/duckstation/duckstation_compat.h
+@@ -12,6 +12,6 @@
+ 
+ #define Panic(msg) assert(false && msg)
+ 
+-#define UnreachableCode() __builtin_unreachable
++#define UnreachableCode() __builtin_unreachable()
+ 
+ #endif
+\ No newline at end of file
+-- 
+2.41.0
+

--- a/games/melonds/files/patch-backport-e6cc4b14b0
+++ b/games/melonds/files/patch-backport-e6cc4b14b0
@@ -1,0 +1,32 @@
+From e6cc4b14b0eb603001e968be9b1ace8a09e1bce1 Mon Sep 17 00:00:00 2001
+From: Nadia Holmquist Pedersen <nadia@nhp.sh>
+Date: Sun, 16 Jul 2023 15:46:50 +0200
+Subject: [PATCH] Work around a strange bug in Qt5 that causes melonDS to crash
+ on launch
+
+...but only with LTO enabled
+...but only on some UNIX systems
+...but only with some additional build options except when it breaks
+   without any as well
+---
+ src/frontend/qt_sdl/CMakeLists.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git src/frontend/qt_sdl/CMakeLists.txt src/frontend/qt_sdl/CMakeLists.txt
+index 0ae6ecea..24261030 100644
+--- src/frontend/qt_sdl/CMakeLists.txt
++++ src/frontend/qt_sdl/CMakeLists.txt
+@@ -222,4 +222,10 @@ if (UNIX AND NOT APPLE)
+ 
+     install(FILES ${CMAKE_SOURCE_DIR}/res/net.kuribo64.melonDS.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+     install(TARGETS melonDS BUNDLE DESTINATION ${CMAKE_BINARY_DIR} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++
++    if (NOT USE_QT6)
++        set_target_properties(melonDS PROPERTIES
++            INTERPROCEDURAL_OPTIMIZATION OFF
++            INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
++    endif()
+ endif()
+-- 
+2.41.0
+


### PR DESCRIPTION
This updates the melonDS emulator to 0.9.5, which is the latest stable version.

This required backporting a patch which fixes compilation with newer versions of clang, as well as backporting another patch that I just made upstream that fixes a strange issue with the Qt 5 flavor crashing immediately on launch on some configurations, notably FreeBSD and apparently also some Linux systems.

This is my first contribution to ports so I hope I've done everything right, and if there's something upstream could do to make it easier to package for BSD, please do let me know :)

Edit: force pushed an amended commit because I realized I forgot to update the dependencies.