### PR TITLE
misc/tzdiff: update to 1.2.

### DIFF
--- a/misc/tzdiff/Makefile
+++ b/misc/tzdiff/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	tzdiff
-PORTVERSION=	1.1.1
+PORTVERSION=	1.2
 CATEGORIES=	misc
 
 MAINTAINER=	naito.yuichiro@gmail.com

--- a/misc/tzdiff/distinfo
+++ b/misc/tzdiff/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1558918946
-SHA256 (belgianbeer-tzdiff-1.1.1_GH0.tar.gz) = e1274a472e16823f5defaf3b908f3cb73b314c46bbb22f019bd8e4b7b318c992
-SIZE (belgianbeer-tzdiff-1.1.1_GH0.tar.gz) = 4960
+TIMESTAMP = 1689829747
+SHA256 (belgianbeer-tzdiff-1.2_GH0.tar.gz) = 6c3b6afc2bb36b001ee11c091144b8d2c451c699b69be605f2b8a4baf1f55d0a
+SIZE (belgianbeer-tzdiff-1.2_GH0.tar.gz) = 5856


### PR DESCRIPTION
Tzdiff has been updated to 1.2 today. This PR updates misc/tzdiff port
See changes in [README.md](https://github.com/belgianbeer/tzdiff#change-log).
