### PR TITLE
misc/tzdiff: Reorder variables.

### DIFF
--- a/misc/tzdiff/Makefile
+++ b/misc/tzdiff/Makefile
@@ -8,14 +8,13 @@ WWW=		https://github.com/belgianbeer/tzdiff
 
 LICENSE=	BSD2CLAUSE
 
-GH_ACCOUNT=	belgianbeer
-
 USE_GITHUB=	yes
-
-PLIST_FILES=	bin/tzdiff man/man1/tzdiff.1.gz
+GH_ACCOUNT=	belgianbeer
 
 NO_ARCH=	yes
 NO_BUILD=	yes
+
+PLIST_FILES=	bin/tzdiff man/man1/tzdiff.1.gz
 
 do-install:
 	${INSTALL_SCRIPT} ${WRKSRC}/tzdiff \


### PR DESCRIPTION
Reorder variables in order to FreeBSD Porters Handbook. This is the reflection of [the comment in FreeBSD bugzilla](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272610#c1).

1.  Put USE_GITHUB upper on GH_ACCOUNT.
2. Put PLIST_FILES below NO_ARCH & NO_BUILD.