### PR TITLE
[NEW PORT] lang/tcc816 - 65816 fork of Tiny C Compiler

### DIFF
--- a/lang/tcc816/Makefile
+++ b/lang/tcc816/Makefile
@@ -1,0 +1,33 @@
+# Created by: Corey Smith <corsmith@gmail.com>
+
+PORTNAME=	tcc
+PKGNAMESUFFIX=	816
+DISTVERSION=	0.9.25
+CATEGORIES=	lang
+
+MAINTAINER=	freebsd@darkain.com
+COMMENT=	WDC 65816 fork of the Tiny C Compiler (TCC)
+WWW=		https://github.com/alekmaul/tcc
+
+LICENSE=		MIT
+LICENSE_FILE_MIT=	${WRKSRC}/RELICENSING
+
+# BUILD_DEPENDS=	as:devel/binutils
+
+USES=			gmake
+HAS_CONFIGURE=  yes
+CONFIGURE_ARGS= --prefix="${PREFIX}" --cc="${CC}"
+
+USE_GITHUB=	yes
+GH_ACCOUNT= alekmaul
+GH_TAGNAME= 10810db6
+
+PLIST_FILES=	bin/816-tcc
+
+.include <bsd.port.pre.mk>
+
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/816-tcc ${STAGEDIR}${PREFIX}/bin/
+
+.include <bsd.port.post.mk>

--- a/lang/tcc816/Makefile
+++ b/lang/tcc816/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	tcc
-PKGNAMESUFFIX=	816
 DISTVERSION=	0.9.25
 CATEGORIES=	lang
+PKGNAMESUFFIX=	816
 
 MAINTAINER=	freebsd@darkain.com
 COMMENT=	WDC 65816 fork of the Tiny C Compiler (TCC)
@@ -21,7 +21,6 @@ GH_TAGNAME= 10810db6
 PLIST_FILES=	bin/816-tcc
 
 .include <bsd.port.pre.mk>
-
 
 do-install:
 	${INSTALL_PROGRAM} ${WRKSRC}/816-tcc ${STAGEDIR}${PREFIX}/bin/

--- a/lang/tcc816/Makefile
+++ b/lang/tcc816/Makefile
@@ -10,8 +10,6 @@ WWW=		https://github.com/alekmaul/tcc
 LICENSE=		MIT
 LICENSE_FILE_MIT=	${WRKSRC}/RELICENSING
 
-# BUILD_DEPENDS=	as:devel/binutils
-
 USES=			gmake
 HAS_CONFIGURE=  yes
 CONFIGURE_ARGS= --prefix="${PREFIX}" --cc="${CC}"

--- a/lang/tcc816/Makefile
+++ b/lang/tcc816/Makefile
@@ -1,5 +1,3 @@
-# Created by: Corey Smith <corsmith@gmail.com>
-
 PORTNAME=	tcc
 PKGNAMESUFFIX=	816
 DISTVERSION=	0.9.25

--- a/lang/tcc816/distinfo
+++ b/lang/tcc816/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1692904691
+SHA256 (alekmaul-tcc-0.9.25-10810db6_GH0.tar.gz) = e3e57f3c3045f0dbfb3955e2a427d4af27912def5c577e3e3d361e8534f91c3b
+SIZE (alekmaul-tcc-0.9.25-10810db6_GH0.tar.gz) = 236850

--- a/lang/tcc816/pkg-descr
+++ b/lang/tcc816/pkg-descr
@@ -1,0 +1,4 @@
+A fork of the the Tiny C Compiler (TCC) for the WDC 65816 CPU
+
+This CPU is used by the Super Nintendo Entertainment System (SNES)
+and the Super Famicom (SFC), as well as other devices from that era.


### PR DESCRIPTION
A fork of the the Tiny C Compiler (TCC) for the WDC 65816 CPU

This CPU is used by the Super Nintendo Entertainment System (SNES)
and the Super Famicom (SFC), as well as other devices from that era.
