### PR TITLE
upgrade java/intellij-ultimate to 2022.2.5

### DIFF
--- a/java/intellij-ultimate/Makefile
+++ b/java/intellij-ultimate/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	intellij-ultimate
-DISTVERSION=	2022.2.3
+DISTVERSION=	2022.2.5
 CATEGORIES=	java devel
-MASTER_SITES=	https://download-cf.jetbrains.com/idea/
+MASTER_SITES=	https://download-cdn.jetbrains.com/idea/
 DISTNAME=	ideaIU-${DISTVERSION}-no-jbr
 DIST_SUBDIR=	jetbrains
 
@@ -33,7 +33,7 @@ NO_BUILD=	yes
 SUB_FILES=	idea idea.desktop pkg-message
 
 BUILD_TYPE=	IU
-BUILD_VERSION=	222.4345.14
+BUILD_VERSION=	222.4554.10
 BUILD_MARKER=	${BUILD_TYPE}-${BUILD_VERSION}
 PLIST_SUB=	BUILD_MARKER=${BUILD_MARKER}
 WRKSRC=		${WRKDIR}/idea-${BUILD_MARKER}
@@ -69,7 +69,7 @@ do-install:
 	${INSTALL_MAN} ${FILESDIR}/idea.1 ${STAGEDIR}${PREFIX}/man/man1
 	${INSTALL_DATA} ${WRKDIR}/idea.desktop ${STAGEDIR}${PREFIX}/share/applications/
 # Use fsnotifier replacement provided by java/intellij-fsnotifier
-	${ECHO} "idea.filewatcher.executable.path=${PREFIX}/intellij/bin/fsnotifier" >> ${STAGEDIR}${DATADIR}/bin/idea.properties
+	${ECHO} "idea.filewatcher.executable.path=${PREFIX}/bin/fsnotifier" >> ${STAGEDIR}${DATADIR}/bin/idea.properties
 # Use pty4j replacement provided by java/intellij-pty4j
 	${LN} -sf ../../../intellij/lib/libpty ${STAGEDIR}${DATADIR}/lib/pty4j-native
 # Fix "Typeahead timeout is exceeded" error

--- a/java/intellij-ultimate/distinfo
+++ b/java/intellij-ultimate/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1665389866
-SHA256 (jetbrains/ideaIU-2022.2.3-no-jbr.tar.gz) = 7454d7e0b8f4e3d8d805dde645d28b842101bd77aea8b29125880c592e6b8c85
-SIZE (jetbrains/ideaIU-2022.2.3-no-jbr.tar.gz) = 860025727
+TIMESTAMP = 1695441982
+SHA256 (jetbrains/ideaIU-2022.2.5-no-jbr.tar.gz) = 6691592a169537327da1b694a4dde1e76ff0d311f6ea20f7c36da6c278b07eaa
+SIZE (jetbrains/ideaIU-2022.2.5-no-jbr.tar.gz) = 860098133


### PR DESCRIPTION
The latest version without jbr is 2022.2.5. The download links for other versions can be found at [jetbrains](https://www.jetbrains.com/idea/download/other.html).
It can be downloaded via [download-cf@jetbrains](https://download-cf.jetbrains.com/idea/ideaIU-2022.2.5-no-jbr.tar.gz) or [download-cdn@jetbrains](https://download-cdn.jetbrains.com/idea/ideaIU-2022.2.5-no-jbr.tar.gz)