### PR TITLE
jenkins: Default to Java 21

### DIFF
--- a/devel/jenkins/Makefile
+++ b/devel/jenkins/Makefile
@@ -14,7 +14,7 @@ WWW=		https://jenkins.io/
 LICENSE=	MIT
 
 USES=		cpe
-USE_JAVA=	11+
+USE_JAVA=	21+
 USE_RC_SUBR=	jenkins
 
 CONFLICTS=	jenkins-lts


### PR DESCRIPTION
Starting with 2.426, Jenkins supports and recommends using Java 21. Older and non LTS versions emit warnings.