### PR TITLE
www/linux-widevine-cdm: Update to 4.10.2710.0

### DIFF
--- a/www/linux-widevine-cdm/Makefile
+++ b/www/linux-widevine-cdm/Makefile
@@ -2,7 +2,7 @@
 # https://aur.archlinux.org/cgit/aur.git/?h=vivaldi-widevine
 
 PORTNAME=	widevine-cdm
-PORTVERSION=	4.10.2662.3
+PORTVERSION=	4.10.2710.0
 CATEGORIES=	www multimedia linux
 MASTER_SITES=	https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/
 PKGNAMEPREFIX=	linux-
@@ -24,7 +24,7 @@ NO_BUILD=	yes
 PLIST_FILES=	lib/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so \
 		lib/WidevineCdm/manifest.json
 
-CHROME_VERSION=	116.0.5845.179-1
+CHROME_VERSION=	121.0.6167.85-1
 
 post-extract:
 	cd ${WRKDIR} && ${EXTRACT_CMD} ${EXTRACT_BEFORE_ARGS} data.tar.xz ${EXTRACT_AFTER_ARGS}

--- a/www/linux-widevine-cdm/distinfo
+++ b/www/linux-widevine-cdm/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1696769064
-SHA256 (google-chrome-stable_116.0.5845.179-1_amd64.deb) = 75d091c547b4f336c88e45c61ba8b7a6fddb869034122b3ffe0ed60225c389b4
-SIZE (google-chrome-stable_116.0.5845.179-1_amd64.deb) = 96683480
+TIMESTAMP = 1706188245
+SHA256 (google-chrome-stable_121.0.6167.85-1_amd64.deb) = f6f3d002264fc3ad2820b9b41dee08cfd94e73e5afb4708113d0870357a373bb
+SIZE (google-chrome-stable_121.0.6167.85-1_amd64.deb) = 106421968


### PR DESCRIPTION
Update Widevine CDM library to the latest version
@arrowd 