### PR TITLE
net/miniupnpd: Update package description to include PCP as supported

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -4,7 +4,7 @@ PORTEPOCH=	1
 CATEGORIES=	net
 
 MAINTAINER=	squat@squat.no
-COMMENT=	UPnP IGD implementation which uses pf
+COMMENT=	Lightweight UPnP IGD & PCP/NAT-PMP daemon which uses pf
 WWW=		http://miniupnp.free.fr/
 
 LICENSE=	BSD3CLAUSE

--- a/net/miniupnpd/pkg-descr
+++ b/net/miniupnpd/pkg-descr
@@ -1,3 +1,3 @@
-Mini UPnPd is a lightweight implementation of a UPnP IGD daemon. This is
-supposed to be run on your gateway machine to allow client systems to redirect
-ports and punch holes in the firewall.
+MiniUPnPd is a lightweight implementation of a UPnP IGD & PCP/NAT-PMP daemon.
+This is supposed to be run on your gateway machine to allow client systems to
+map ports on the firewall.


### PR DESCRIPTION
Port Control Protocol (PCP) is the successor to NAT-PMP and has similar protocol concepts and packet formats, but adds IPv6 support.

*PCP standard:*
https://datatracker.ietf.org/doc/html/rfc6887
https://en.wikipedia.org/wiki/Port_Control_Protocol
*NAT-PMP std. (see 9.1 Simplicity - 9.3 for some diff. to UPnP IGD):*
https://datatracker.ietf.org/doc/html/rfc6886