### PR TITLE
Add security/xhash

### DIFF
--- a/security/xhash/Makefile
+++ b/security/xhash/Makefile
@@ -1,0 +1,26 @@
+PORTNAME=	xhash
+DISTVERSIONPREFIX=	v
+DISTVERSION=	3.3.1
+CATEGORIES=	security
+
+MAINTAINER=	rbranco@suse.de
+COMMENT=	Calculate hashes on files using goroutines
+WWW=		https://github.com/ricardobranco777/xhash/
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+USES=		go:modules,1.21
+USE_GITHUB=	yes
+GH_ACCOUNT=	ricardobranco777
+#GO_MODULE=	github.com/ricardobranco777/xhash
+GH_TUPLE=	\
+		golang:crypto:v0.19.0:golang_crypto/vendor/golang.org/x/crypto \
+		golang:sys:v0.17.0:golang_sys/vendor/golang.org/x/sys \
+		klauspost:cpuid:v2.0.12:klauspost_cpuid_v2/vendor/github.com/klauspost/cpuid/v2 \
+		spf13:pflag:v1.0.5:spf13_pflag/vendor/github.com/spf13/pflag \
+		zeebo:blake3:v0.2.3:zeebo_blake3/vendor/github.com/zeebo/blake3
+
+PLIST_FILES=	bin/xhash
+
+.include <bsd.port.mk>

--- a/security/xhash/distinfo
+++ b/security/xhash/distinfo
@@ -1,0 +1,13 @@
+TIMESTAMP = 1708629232
+SHA256 (ricardobranco777-xhash-v3.3.1_GH0.tar.gz) = 13a25ec167734c64a6d8d13b243714269b80f33ceb5e68f5203d7834447e500e
+SIZE (ricardobranco777-xhash-v3.3.1_GH0.tar.gz) = 14728
+SHA256 (golang-crypto-v0.19.0_GH0.tar.gz) = 0e1d6c17f9c6f529d2d06e43030695ba135115ee401fda5316d6b30423087bb2
+SIZE (golang-crypto-v0.19.0_GH0.tar.gz) = 1810389
+SHA256 (golang-sys-v0.17.0_GH0.tar.gz) = ac396e3c66940e34fdd1d422a9628ab2a5118249118f2a36f65082d32e709e7a
+SIZE (golang-sys-v0.17.0_GH0.tar.gz) = 1446309
+SHA256 (klauspost-cpuid-v2.0.12_GH0.tar.gz) = ac723eecde24ff08a2fa4b3989b602ab2ecd607f132845b66c26aae896f7130a
+SIZE (klauspost-cpuid-v2.0.12_GH0.tar.gz) = 343262
+SHA256 (spf13-pflag-v1.0.5_GH0.tar.gz) = 9a2cae1f8e8ab0d2cc8ebe468e871af28d9ac0962cf0520999e3ba85f0c7b808
+SIZE (spf13-pflag-v1.0.5_GH0.tar.gz) = 50796
+SHA256 (zeebo-blake3-v0.2.3_GH0.tar.gz) = fef93a1e03d60c0b11fbf11a36110ae87b3105e1c5cfa3b7bbb4af9b87bd2a4b
+SIZE (zeebo-blake3-v0.2.3_GH0.tar.gz) = 110842

--- a/security/xhash/pkg-descr
+++ b/security/xhash/pkg-descr
@@ -1,0 +1,1 @@
+This Go program uses goroutines to calculate multiple hashes on strings, files and directories.  By default it reads from standard input.  It can be used as a drop-in replacement for the GNU **coreutils** when hard-linked as **md5sum**, etc. and it actually supports the `--zero` option with `--check`.  The output format is fully configurable.


### PR DESCRIPTION
Add security/xhash

This Go program uses goroutines to calculate multiple hashes on strings, files and directories.  By default it reads from standard input.  It can be used as a drop-in replacement for the GNU **coreutils** when hard-linked as **md5sum**, etc. and it actually supports the `--zero` option with `--check`.  The output format is fully configurable.