### PR TITLE
comms/hackrf: port update 2021.03.1->2024.02.1.

### DIFF
--- a/comms/hackrf/Makefile
+++ b/comms/hackrf/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	hackrf
-PORTVERSION=	2021.03.1
-PORTREVISION=	1
+PORTVERSION=	2024.02.1
 CATEGORIES=	comms devel hamradio science security
 
 MAINTAINER=	tomek@cedro.info
@@ -9,13 +8,12 @@ WWW=		https://greatscottgadgets.com/hackrf/
 
 LICENSE=	GPLv2
 
-LIB_DEPENDS=	libfftw3.so:math/fftw3 \
-		libfftw3f.so:math/fftw3-float
+LIB_DEPENDS=	libfftw3f.so:math/fftw3-float
 
 USES=		cmake
 USE_GITHUB=	YES
-GH_ACCOUNT=	mossmann
-GH_TAGNAME=	e6eb4ba
+GH_ACCOUNT=	greatscottgadgets
+GH_TAGNAME=	18b485e
 
 CONFLICTS=	hackrf-devel
 

--- a/comms/hackrf/distinfo
+++ b/comms/hackrf/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1664724612
-SHA256 (mossmann-hackrf-2021.03.1-e6eb4ba_GH0.tar.gz) = ebb626db99d442a90e9306bf79ff2fc9e03063997eb3d993b981633668179cc2
-SIZE (mossmann-hackrf-2021.03.1-e6eb4ba_GH0.tar.gz) = 13064632
+TIMESTAMP = 1708750351
+SHA256 (greatscottgadgets-hackrf-2024.02.1-18b485e_GH0.tar.gz) = d3b54356f5126e63915223479e6264c514141f228a74d37725364920683ff1c4
+SIZE (greatscottgadgets-hackrf-2024.02.1-18b485e_GH0.tar.gz) = 13133386

--- a/comms/hackrf/pkg-plist
+++ b/comms/hackrf/pkg-plist
@@ -1,3 +1,4 @@
+bin/hackrf_biast
 bin/hackrf_clock
 bin/hackrf_cpldjtag
 bin/hackrf_debug
@@ -10,5 +11,5 @@ include/libhackrf/hackrf.h
 lib/libhackrf.a
 lib/libhackrf.so
 lib/libhackrf.so.0
-lib/libhackrf.so.0.6.0
+lib/libhackrf.so.0.9.0
 libdata/pkgconfig/libhackrf.pc


### PR DESCRIPTION
Release 2024.02.1 notes:
https://github.com/greatscottgadgets/hackrf/releases/tag/v2024.02.1