### PR TITLE
x11/gbsddialog: update to 0.9.0

### DIFF
--- a/x11/gbsddialog/Makefile
+++ b/x11/gbsddialog/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gbsddialog
-DISTVERSION=	0.8.1
+DISTVERSION=	0.9.0
 CATEGORIES=	x11
 MASTER_SITES=	${WWW}/releases/download/${PORTNAME}_${DISTVERSION:S/./-/g}/
 

--- a/x11/gbsddialog/distinfo
+++ b/x11/gbsddialog/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1708207721
-SHA256 (gbsddialog-0.8.1.tar.gz) = 2b08ea0dff3f8a5fdf99571a92ae996a5713596769231030093201ed63679de5
-SIZE (gbsddialog-0.8.1.tar.gz) = 76238
+TIMESTAMP = 1709665535
+SHA256 (gbsddialog-0.9.0.tar.gz) = d35ae3bc81b7b603faa6da975d1c73e230af5a228ab8064f48761abac2b43f04
+SIZE (gbsddialog-0.9.0.tar.gz) = 77859


### PR DESCRIPTION
Changes:
https://github.com/khorben/gbsddialog/compare/gbsddialog_0-8-1..gbsddialog_0-9-0

Sponsored by:	The FreeBSD Foundation