### PR TITLE
irc/anope: update pkg-descr to match the actually supported ircds.

### DIFF
--- a/irc/anope/pkg-descr
+++ b/irc/anope/pkg-descr
@@ -4,19 +4,13 @@ administrators to manage their network with powerful tools.
 
 Anope currently works with:
   - Bahamut 1.4.27 or later (including 1.8)
-  - Charybdis 1.0 or later
-  - DreamForge 4.6.7
-  - Hybrid 7 or later
-  - InspIRCd 1.0 or later (including 3.x)
-  - Plexus 2.0 or later (including 3.0)
-  - PTlink 6.15 or later
-  - RageIRCd 2.0 beta-6 or later
+  - Charybdis 3.4 or later
+  - ircd-hybrid 8.2.23 or later
+  - InspIRCd 1.2 or later
+  - ngIRCd 19.2 or later
+  - Plexus 3 or later
   - Ratbox 2.0.6 or later
-  - ShadowIRCd 4.0 beta 7 or later
-  - Solid IRCd 3.4.6 or later
-  - UltimateIRCd 2.8.2 or later (including 3.0)
-  - UnrealIRCd 3.1.1 or later (including 6.x)
-  - ViagraIRCd 1.3 or later
+  - UnrealIRCd 3.2 or later
 
 Anope could also work with some of the daemons derived by the ones listed
 above, but there's no support for them if they work or don't work.


### PR DESCRIPTION
I'm the upstream for this software. Most of these IRCds haven't been supported since 1.8 which went EOL almost a decade ago.

This description was copied from `docs/README` so I just updated it to match the current list.