### PR TITLE
security/xhash: Bump to v3.3.3, go122 and latest dependencies

### DIFF
--- a/security/xhash/Makefile
+++ b/security/xhash/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	xhash
 DISTVERSIONPREFIX=	v
-DISTVERSION=	3.3.2
-PORTREVISION=	3
+DISTVERSION=	3.3.3
+#PORTREVISION=	1
 CATEGORIES=	security
 
 MAINTAINER=	rbranco@suse.de
@@ -14,10 +14,9 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 USES=		go:modules,1.21
 USE_GITHUB=	yes
 GH_ACCOUNT=	ricardobranco777
-#GO_MODULE=	github.com/ricardobranco777/xhash
 GH_TUPLE=	\
-		golang:crypto:v0.19.0:golang_crypto/vendor/golang.org/x/crypto \
-		golang:sys:v0.17.0:golang_sys/vendor/golang.org/x/sys \
+		golang:crypto:v0.23.0:golang_crypto/vendor/golang.org/x/crypto \
+		golang:sys:v0.20.0:golang_sys/vendor/golang.org/x/sys \
 		klauspost:cpuid:v2.0.12:klauspost_cpuid_v2/vendor/github.com/klauspost/cpuid/v2 \
 		spf13:pflag:v1.0.5:spf13_pflag/vendor/github.com/spf13/pflag \
 		zeebo:blake3:v0.2.3:zeebo_blake3/vendor/github.com/zeebo/blake3

--- a/security/xhash/distinfo
+++ b/security/xhash/distinfo
@@ -1,10 +1,10 @@
-TIMESTAMP = 1709054234
-SHA256 (ricardobranco777-xhash-v3.3.2_GH0.tar.gz) = 4a43ea5e6f36ab0c21ea89a080ff6134a7c0beabd4ed47d4f8f3ed562870e32a
-SIZE (ricardobranco777-xhash-v3.3.2_GH0.tar.gz) = 14889
-SHA256 (golang-crypto-v0.19.0_GH0.tar.gz) = 0e1d6c17f9c6f529d2d06e43030695ba135115ee401fda5316d6b30423087bb2
-SIZE (golang-crypto-v0.19.0_GH0.tar.gz) = 1810389
-SHA256 (golang-sys-v0.17.0_GH0.tar.gz) = ac396e3c66940e34fdd1d422a9628ab2a5118249118f2a36f65082d32e709e7a
-SIZE (golang-sys-v0.17.0_GH0.tar.gz) = 1446309
+TIMESTAMP = 1716122329
+SHA256 (ricardobranco777-xhash-v3.3.3_GH0.tar.gz) = 922f1d6f05a4f267e7343450a1a57a7e260d7ea2e726d164532d1d039253be6a
+SIZE (ricardobranco777-xhash-v3.3.3_GH0.tar.gz) = 14963
+SHA256 (golang-crypto-v0.23.0_GH0.tar.gz) = e6cfbf5f44d6b89b748c87fdbabd04c9634c5b825e39032a69854c300be9fb43
+SIZE (golang-crypto-v0.23.0_GH0.tar.gz) = 1813872
+SHA256 (golang-sys-v0.20.0_GH0.tar.gz) = eb2569cab8d7a92ce3afa9119538b61fc03d575c01f1548ec1e152c330ac591d
+SIZE (golang-sys-v0.20.0_GH0.tar.gz) = 1494604
 SHA256 (klauspost-cpuid-v2.0.12_GH0.tar.gz) = ac723eecde24ff08a2fa4b3989b602ab2ecd607f132845b66c26aae896f7130a
 SIZE (klauspost-cpuid-v2.0.12_GH0.tar.gz) = 343262
 SHA256 (spf13-pflag-v1.0.5_GH0.tar.gz) = 9a2cae1f8e8ab0d2cc8ebe468e871af28d9ac0962cf0520999e3ba85f0c7b808


### PR DESCRIPTION
Bump to v3.3.3, go122 and latest dependencies

Ref: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=279158