### PR TITLE
x11/gbsddialog: update to 0.9.1

### DIFF
--- a/x11/gbsddialog/Makefile
+++ b/x11/gbsddialog/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gbsddialog
-DISTVERSION=	0.9.0
+DISTVERSION=	0.9.1
 CATEGORIES=	x11
 MASTER_SITES=	${WWW}/releases/download/${PORTNAME}_${DISTVERSION:S/./-/g}/
 

--- a/x11/gbsddialog/distinfo
+++ b/x11/gbsddialog/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1709665535
-SHA256 (gbsddialog-0.9.0.tar.gz) = d35ae3bc81b7b603faa6da975d1c73e230af5a228ab8064f48761abac2b43f04
-SIZE (gbsddialog-0.9.0.tar.gz) = 77859
+TIMESTAMP = 1716812514
+SHA256 (gbsddialog-0.9.1.tar.gz) = f0340df37afc5c508ec21a443b26d60574039b0826ca819ddbbf60c2911f351d
+SIZE (gbsddialog-0.9.1.tar.gz) = 77892


### PR DESCRIPTION
This release improves the --gauge dialog specifically.

Sponsored by:   The FreeBSD Foundation