### PR TITLE
security/osv-scanner: Update to 1.8.1

### DIFF
--- a/security/osv-scanner/Makefile
+++ b/security/osv-scanner/Makefile
@@ -1,7 +1,6 @@
 PORTNAME=	osv-scanner
 DISTVERSIONPREFIX=	v
-DISTVERSION=	1.7.1
-PORTREVISION=	3
+DISTVERSION=	1.8.1
 CATEGORIES=	security
 
 MAINTAINER=	lcook@FreeBSD.org
@@ -14,7 +13,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 USES=		go:1.21,modules
 
 _BUILD_VERSION=	${DISTVERSION}
-_BUILD_COMMIT=	43dda7a
+_BUILD_COMMIT=	46aee59
 _BUILD_DATE=	$$(date +%Y-%m-%d)
 
 GO_MODULE=	github.com/google/${PORTNAME}
@@ -29,6 +28,10 @@ PORTDOCS=	CHANGELOG.md CONTRIBUTING.md README.md
 PLIST_FILES=	${GO_TARGET:C/.\/cmd/bin/}
 
 OPTIONS_DEFINE=	DOCS
+
+post-patch:
+	@${REINPLACE_CMD} -e 's,%%GO_SUFFIX%%,${GO_SUFFIX},' \
+		${WRKSRC}/internal/sourceanalysis/go.go
 
 post-install-DOCS-on:
 	@${MKDIR} ${STAGEDIR}${DOCSDIR}

--- a/security/osv-scanner/distinfo
+++ b/security/osv-scanner/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1712438042
-SHA256 (go/security_osv-scanner/osv-scanner-v1.7.1/v1.7.1.mod) = df7aa5bea0f40ac2e6bc31e19db8246217bd168f106e0e559f30f51e7331a27a
-SIZE (go/security_osv-scanner/osv-scanner-v1.7.1/v1.7.1.mod) = 5059
-SHA256 (go/security_osv-scanner/osv-scanner-v1.7.1/v1.7.1.zip) = c621713f2bb76a5cca3235bb2266ce7d6377f2c9bf7569bf551fa2e69987b443
-SIZE (go/security_osv-scanner/osv-scanner-v1.7.1/v1.7.1.zip) = 3958644
+TIMESTAMP = 1718988404
+SHA256 (go/security_osv-scanner/osv-scanner-v1.8.1/v1.8.1.mod) = 233a43d973ea3e5ddbc330b70ca88534c2abe7d0694f5132c97f56ac0c6148df
+SIZE (go/security_osv-scanner/osv-scanner-v1.8.1/v1.8.1.mod) = 5340
+SHA256 (go/security_osv-scanner/osv-scanner-v1.8.1/v1.8.1.zip) = 0559c1690bfcee4310e975836ec0e805b7f85d8492874869d077fe4cb73ff47a
+SIZE (go/security_osv-scanner/osv-scanner-v1.8.1/v1.8.1.zip) = 6845140

--- a/security/osv-scanner/files/patch-internal_sourceanalysis_go.go
+++ b/security/osv-scanner/files/patch-internal_sourceanalysis_go.go
@@ -1,0 +1,11 @@
+--- internal/sourceanalysis/go.go.orig	2024-06-21 19:21:07.662367000 +0200
++++ internal/sourceanalysis/go.go	2024-06-21 19:21:27.715630000 +0200
+@@ -18,7 +18,7 @@
+ )
+ 
+ func goAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.SourceInfo) {
+-	cmd := exec.Command("go", "version")
++	cmd := exec.Command("go%%GO_SUFFIX%%", "version")
+ 	_, err := cmd.Output()
+ 	if err != nil {
+ 		r.Infof("Skipping call analysis on Go code since Go is not installed.\n")


### PR DESCRIPTION
Changes:
https://github.com/google/osv-scanner/compare/v1.7.1...v1.8.1

This also fixes detecting if Go is installed locally at run-time, when
checking for known vulnerabilities against source code written in Go.

Sponsored by:	The FreeBSD Foundation