### PR TITLE
multimedia/wireplumber: Install the enabling config for Pipewire

### DIFF
--- a/multimedia/wireplumber/Makefile
+++ b/multimedia/wireplumber/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	wireplumber
 DISTVERSION=	0.5.6
+PORTREVISION=	1
 CATEGORIES=	multimedia
 
 MAINTAINER=	arrowd@FreeBSD.org
@@ -43,5 +44,10 @@ PORTDOCS=	*
 post-patch:
 	${REINPLACE_CMD} -e "s|'python3'|'python${PYTHON_VER}'|" \
 		${WRKSRC}/docs/meson.build
+
+post-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/share/pipewire/pipewire.conf.d
+	${SED} -e 's|%%WIREPLUMBER_CMD%%|${PREFIX}/bin/wireplumber|' \
+		${PATCHDIR}/10-wireplumber.in > ${STAGEDIR}${PREFIX}/share/pipewire/pipewire.conf.d/10-wireplumber.conf
 
 .include <bsd.port.mk>

--- a/multimedia/wireplumber/files/10-wireplumber.in
+++ b/multimedia/wireplumber/files/10-wireplumber.in
@@ -1,0 +1,4 @@
+context.exec = [
+    { path = "%%WIREPLUMBER_CMD%%" args = ""
+      condition = [ { exec.session-manager = null } { exec.session-manager = true } ] }
+]

--- a/multimedia/wireplumber/pkg-plist
+++ b/multimedia/wireplumber/pkg-plist
@@ -115,6 +115,7 @@ libdata/pkgconfig/wireplumber-0.5.pc
 %%NLS%%share/locale/uk/LC_MESSAGES/wireplumber.mo
 %%NLS%%share/locale/zh_CN/LC_MESSAGES/wireplumber.mo
 %%NLS%%share/locale/zh_TW/LC_MESSAGES/wireplumber.mo
+share/pipewire/pipewire.conf.d/10-wireplumber.conf
 %%DATADIR%%/scripts/client/access-default.lua
 %%DATADIR%%/scripts/client/access-portal.lua
 %%DATADIR%%/scripts/client/access-snap.lua


### PR DESCRIPTION
@jbeich Do you have an idea if this is a right thing to do?

I followed the logic from https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/04c5d3958bcad7db46614ac1f0dfdd6d77271bd0/src/daemon/meson.build#L55 which uncomments these lines in the main Pipewire config if Meson is passed `-Dsession-manager=wireplumber`. We don't pass this option because it make Wireplumber to be build as part of Pipewire build.