### PR TITLE
allow ttrssd to run as a specified user (take two)

### DIFF
--- a/www/tt-rss/files/ttrssd.in
+++ b/www/tt-rss/files/ttrssd.in
@@ -7,6 +7,9 @@
 # Add the following lines to /etc/rc.conf to enable `ttrssd':
 #
 # ttrssd_enable="YES"
+#
+# Optional:
+#    ttrssd_run_as_user            The user to run as (default www)
 
 . /etc/rc.subr
 
@@ -18,6 +21,7 @@ rcvar=ttrssd_enable
 # read settings, set default values
 load_rc_config "${name}"
 : ${ttrssd_enable="NO"}
+: ${ttrssd_run_as_user="%%WWWOWN%%"}
 
 long_name="Tiny Tiny RSS updating feeds daemon."
 required_files="%%WWWDIR%%/config.php"
@@ -30,7 +34,7 @@ phpupd="%%WWWDIR%%/update_daemon2.php"
 ttrssd_log="/var/log/${name}.log"
 
 command="/usr/sbin/daemon"
-command_args="-rR 10 -H -u %%WWWOWN%% \
+command_args="-rR 10 -H -u $ttrssd_run_as_user \
 		-P $pidfile -p $cpidfile \
 		-o $ttrssd_log sh -c \
 		'$initdb_php --update-schema=force-yes; \

--- a/www/tt-rss/pkg-plist
+++ b/www/tt-rss/pkg-plist
@@ -1,7 +1,7 @@
 %%DATADIR%%/httpd-tt-rss.conf
 @sample %%EXAMPLESDIR%%/newsyslog.sample etc/newsyslog.conf.d/ttrssd.conf
 @group %%WWWGRP%%
-@mode ug=rx
+@mode ugo=rx
 %%WWWDIR%%/update.php
 %%WWWDIR%%/update_daemon2.php
 @group


### PR DESCRIPTION
The Tiny Tiny RSS update daemon, ``ttrssd``, from package ``www/tt-rss``, currently runs as user ``www``. This change is meant to enable (optionally) running as a different user, by setting a new flag ``ttrssd_run_as_user`` in ``/etc/rc.conf``. For example, to run as the user ``mmm``, add the following line to ``/etc/rc.conf``:

```
ttrssd_run_as_user="mmm"
```

If this new flag is not specified, it defaults to running as ``www`` (reproducing the behavior from before this change).

I've modified [my previous PR](https://github.com/freebsd/freebsd-ports/pull/304) for this as suggested by @derekschrock: