### PR TITLE
textproc/py-towncrier23: fix to build with py-incremental 24.7.2

### DIFF
--- a/textproc/py-towncrier23/Makefile
+++ b/textproc/py-towncrier23/Makefile
@@ -14,6 +14,7 @@ LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}hatchling>=1.17.1:devel/py-hatchling@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}setuptools>=0:devel/py-setuptools@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}incremental>=0:devel/py-incremental@${PY_FLAVOR}
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}click>=0:devel/py-click@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}importlib-resources>=5:devel/py-importlib-resources@${PY_FLAVOR} \


### PR DESCRIPTION
Recently, our build for textproc/py-towncrier23 was broken and failed with:
    ===>  Building for py311-towncrier23-23.11.0
    * Getting build dependencies for wheel...

    ERROR Missing dependencies:
            incremental
            setuptools>=61.0
    *** Error code 1

    Stop.

Commit 0472a238188abdac5673554480581a30495dbc73 updated devel/py-incremental and we saw devel/py-twisted/Makefile was patched in commit 020ab85a0ee56477048e5402b5577745dcead362. That changes seem to fix our py-towncrier build, too.