### PR TITLE
Fix man page reference for paperless-ngx

### DIFF
--- a/deskutils/py-paperless-ngx/files/patch-paperless.conf.example
+++ b/deskutils/py-paperless-ngx/files/patch-paperless.conf.example
@@ -55,6 +55,6 @@
  #PAPERLESS_CONVERT_BINARY=/usr/bin/convert
  #PAPERLESS_GS_BINARY=/usr/bin/gs
 +
-+# NLTK settings - see `man 7 paperless`
++# NLTK settings - see `man 7 paperless-ngx`
 +PAPERLESS_NLTK_DIR=/var/db/paperless/nltkdata
 +PAPERLESS_ENABLE_NLTK=yes


### PR DESCRIPTION
Hi,

the config file for paperless-ngx has a reference to a man page which does not exist in the pkg.

Best,
Malte