### PR TITLE
misc/mc: fix packaging WITHOUT_EDITOR

### DIFF
--- a/misc/mc/pkg-plist
+++ b/misc/mc/pkg-plist
@@ -144,7 +144,7 @@ libexec/mc/shell/utime
 %%NLS%%share/man/it/man1/mc.1.gz
 share/man/man1/mc.1.gz
 share/man/man1/mcdiff.1.gz
-share/man/man1/mcedit.1.gz
+%%EDITOR%%share/man/man1/mcedit.1.gz
 share/man/man1/mcview.1.gz
 %%NLS%%share/man/pl/man1/mc.1.gz
 %%NLS%%share/man/ru/man1/mc.1.gz


### PR DESCRIPTION
If the operator disables building the port with editor, packaging of the port fails, since pkg-plist will believe editor's man shall be installed anyway.