### PR TITLE
security/tlsinfo: init at 0.1.41

### DIFF
--- a/security/tlsinfo/Makefile
+++ b/security/tlsinfo/Makefile
@@ -1,0 +1,19 @@
+PORTNAME=	tlsinfo
+CATEGORIES=	security
+DISTVERSION=    0.1.41
+DISTVERSIONPREFIX=	v
+
+MAINTAINER=	ports@paepcke.de
+COMMENT=        Tool to analyze and troubleshoot TLS Connections
+WWW=		https://paepcke.de/${PORTNAME}
+
+LICENSE=	BSD3CLAUSE
+
+USES=		go:modules
+
+GO_MODULE=	paepcke.de/${PORTNAME}
+GO_TARGET=	./cmd/${PORTNAME} 
+
+PLIST_FILES=	bin/${PORTNAME}
+
+.include <bsd.port.mk>

--- a/security/tlsinfo/distinfo
+++ b/security/tlsinfo/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1729848269
+SHA256 (go/security_tlsinfo/tlsinfo-v0.1.41/v0.1.41.mod) = a905e555229fbef4a126396cd989399d188288b69cbc78d098ddb8daaee9ce5b
+SIZE (go/security_tlsinfo/tlsinfo-v0.1.41/v0.1.41.mod) = 336
+SHA256 (go/security_tlsinfo/tlsinfo-v0.1.41/v0.1.41.zip) = 383202f24a816ae83e5a1700d2040b87fb7d9044c69ded453a64c38db1233c9d
+SIZE (go/security_tlsinfo/tlsinfo-v0.1.41/v0.1.41.zip) = 13374

--- a/security/tlsinfo/pkg-descr
+++ b/security/tlsinfo/pkg-descr
@@ -1,0 +1,1 @@
+Tool to analyse x509, ssh and other certificates.


### PR DESCRIPTION
Tool to analyze and troubleshoot TLS connections (app/lib/api) 
- [x] tested with poudriere
- [x] tested on 14.1-RELEASE
- [x] tested on 15.0-CURRENT 