### PR TITLE
security/certinfo: init at 0.1.36

### DIFF
--- a/security/certinfo/Makefile
+++ b/security/certinfo/Makefile
@@ -1,0 +1,19 @@
+PORTNAME=	certinfo
+CATEGORIES=	security
+DISTVERSION=    0.1.36
+DISTVERSIONPREFIX=	v
+
+MAINTAINER=	ports@paepcke.de
+COMMENT=        Tool to analyze x509, ssh and other certificates
+WWW=		https://paepcke.de/${PORTNAME}
+
+LICENSE=	BSD3CLAUSE
+
+USES=		go:modules
+
+GO_MODULE=	paepcke.de/${PORTNAME}
+GO_TARGET=	./cmd/${PORTNAME} 
+
+PLIST_FILES=	bin/${PORTNAME}
+
+.include <bsd.port.mk>

--- a/security/certinfo/distinfo
+++ b/security/certinfo/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1729847806
+SHA256 (go/security_certinfo/certinfo-v0.1.36/v0.1.36.mod) = e280ac8f6a453469502e6f50ea6e72c12cdc3a952a8e2f6c3b2f63fe734e5edf
+SIZE (go/security_certinfo/certinfo-v0.1.36/v0.1.36.mod) = 296
+SHA256 (go/security_certinfo/certinfo-v0.1.36/v0.1.36.zip) = 6fae0c308308814d228c58c9ff9f4cca06e57915f72eb7b139c7dfc433887ab5
+SIZE (go/security_certinfo/certinfo-v0.1.36/v0.1.36.zip) = 18526

--- a/security/certinfo/pkg-descr
+++ b/security/certinfo/pkg-descr
@@ -1,0 +1,1 @@
+Tool to analyse x509, ssh and other certificates.


### PR DESCRIPTION
Tool to analyze and troubleshoot x.509 & ssh certificates, encoded keys, ...
- [x] tested with poudriere
- [x] tested on 14.1-RELEASE
- [x] tested on 15.0-CURRENT 