### PR TITLE
net/opnborg: init at 0.1.18

### DIFF
--- a/net/opnborg/Makefile
+++ b/net/opnborg/Makefile
@@ -1,0 +1,19 @@
+PORTNAME=	opnborg
+CATEGORIES=	net
+DISTVERSION=    0.1.18
+DISTVERSIONPREFIX=	v
+
+MAINTAINER=	ports@paepcke.de
+COMMENT=        Selfhost-able OPNSense Appliance Configuration, Backup Portal
+WWW=		https://paepcke.de/${PORTNAME}
+
+LICENSE=	BSD3CLAUSE
+
+USES=		go:modules
+
+GO_MODULE=	paepcke.de/${PORTNAME}
+GO_TARGET=	./cmd/${PORTNAME} 
+
+PLIST_FILES=	bin/${PORTNAME}
+
+.include <bsd.port.mk>

--- a/net/opnborg/distinfo
+++ b/net/opnborg/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1729848548
+SHA256 (go/security_opnborg/opnborg-v0.1.18/v0.1.18.mod) = 29b09f30f0c7065cbf1b720db43bea6ec6f9cff4bc66b834f21960f40c726514
+SIZE (go/security_opnborg/opnborg-v0.1.18/v0.1.18.mod) = 1943
+SHA256 (go/security_opnborg/opnborg-v0.1.18/v0.1.18.zip) = af26944fcdcc5909b54ec927aab92635508e6b94cd6c30854750d62ce921c74b
+SIZE (go/security_opnborg/opnborg-v0.1.18/v0.1.18.zip) = 260731

--- a/net/opnborg/pkg-descr
+++ b/net/opnborg/pkg-descr
@@ -1,0 +1,1 @@
+Selfhost-able OPNSense Appliance Configuration, Backup Portal.


### PR DESCRIPTION
Selfhost-able OPNSense Appliance Configuration Managenment & Backup Portal (written in golang, useable via webui, as cli tool, daemon, api or golang-library) 
- [x] tested with poudriere
- [x] tested on 14.1-RELEASE
- [x] tested on 15.0-CURRENT 