### PR TITLE
www/linux-widevine-cdm: Update to 4.10.2830.0

### DIFF
--- a/www/linux-widevine-cdm/Makefile
+++ b/www/linux-widevine-cdm/Makefile
@@ -2,7 +2,7 @@
 # https://aur.archlinux.org/cgit/aur.git/?h=vivaldi-widevine
 
 PORTNAME=	widevine-cdm
-PORTVERSION=	4.10.2710.0
+PORTVERSION=	4.10.2830.0
 CATEGORIES=	www multimedia linux
 MASTER_SITES=	https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/
 PKGNAMEPREFIX=	linux-

--- a/www/linux-widevine-cdm/Makefile
+++ b/www/linux-widevine-cdm/Makefile
@@ -24,7 +24,7 @@ NO_BUILD=	yes
 PLIST_FILES=	lib/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so \
 		lib/WidevineCdm/manifest.json
 
-CHROME_VERSION=	121.0.6167.85-1
+CHROME_VERSION=	128.0.6613.84-1
 
 post-extract:
 	cd ${WRKDIR} && ${EXTRACT_CMD} ${EXTRACT_BEFORE_ARGS} data.tar.xz ${EXTRACT_AFTER_ARGS}

--- a/www/linux-widevine-cdm/distinfo
+++ b/www/linux-widevine-cdm/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1706188245
-SHA256 (google-chrome-stable_121.0.6167.85-1_amd64.deb) = f6f3d002264fc3ad2820b9b41dee08cfd94e73e5afb4708113d0870357a373bb
-SIZE (google-chrome-stable_121.0.6167.85-1_amd64.deb) = 106421968
+TIMESTAMP = 1730714712
+SHA256 (google-chrome-stable_128.0.6613.84-1_amd64.deb) = e21001b470eaffc9483fa61ba54d5525d9a064d98b376a9bd1530f630dddb018
+SIZE (google-chrome-stable_128.0.6613.84-1_amd64.deb) = 110726136


### PR DESCRIPTION
tested on 15.0-CURRENT