### PR TITLE
security/osv-scanner: Update to 1.9.1

### DIFF
--- a/security/osv-scanner/Makefile
+++ b/security/osv-scanner/Makefile
@@ -1,7 +1,6 @@
 PORTNAME=	osv-scanner
 DISTVERSIONPREFIX=	v
-DISTVERSION=	1.8.2
-PORTREVISION=	1
+DISTVERSION=	1.9.1
 CATEGORIES=	security
 
 MAINTAINER=	lcook@FreeBSD.org
@@ -11,10 +10,10 @@ WWW=		https://github.com/google/osv-scanner
 LICENSE=	APACHE20
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-USES=		go:1.21,modules
+USES=		go:1.23,modules
 
 _BUILD_VERSION=	${DISTVERSION}
-_BUILD_COMMIT=	1ea785e
+_BUILD_COMMIT=	b13f37e
 _BUILD_DATE=	$$(date +%Y-%m-%d)
 
 GO_MODULE=	github.com/google/${PORTNAME}
@@ -25,8 +24,8 @@ GO_BUILDFLAGS=	-ldflags "\
 		-X main.date=${_BUILD_DATE} \
 		-X main.commit=${_BUILD_COMMIT}"
 
-PORTDOCS=	CHANGELOG.md CONTRIBUTING.md README.md
 PLIST_FILES=	${GO_TARGET:C/.\/cmd/bin/}
+PORTDOCS=	CHANGELOG.md CONTRIBUTING.md README.md
 
 OPTIONS_DEFINE=	DOCS
 

--- a/security/osv-scanner/distinfo
+++ b/security/osv-scanner/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1720621608
-SHA256 (go/security_osv-scanner/osv-scanner-v1.8.2/v1.8.2.mod) = b330a09097662dda308c1d00070863cec5bab7ad766b431132204e62bcfbd4d0
-SIZE (go/security_osv-scanner/osv-scanner-v1.8.2/v1.8.2.mod) = 5340
-SHA256 (go/security_osv-scanner/osv-scanner-v1.8.2/v1.8.2.zip) = 3f2258a6e28d170b6e59415af5d21a42b3be63dbc9cdf38bc28b080e2a072c37
-SIZE (go/security_osv-scanner/osv-scanner-v1.8.2/v1.8.2.zip) = 6873207
+TIMESTAMP = 1730742574
+SHA256 (go/security_osv-scanner/osv-scanner-v1.9.1/v1.9.1.mod) = 8b46b0c469e2129a38fec377cbdf7ac43380afd538094fe23bd69d2267eb7c61
+SIZE (go/security_osv-scanner/osv-scanner-v1.9.1/v1.9.1.mod) = 5009
+SHA256 (go/security_osv-scanner/osv-scanner-v1.9.1/v1.9.1.zip) = bdb4a6864eacd826398b2cb80a7e0dfc24faaa87171293cbe4f99eef8266afd0
+SIZE (go/security_osv-scanner/osv-scanner-v1.9.1/v1.9.1.zip) = 7477512

--- a/security/osv-scanner/files/patch-internal_sourceanalysis_go.go
+++ b/security/osv-scanner/files/patch-internal_sourceanalysis_go.go
@@ -1,6 +1,6 @@
---- internal/sourceanalysis/go.go.orig	2024-06-21 19:21:07.662367000 +0200
-+++ internal/sourceanalysis/go.go	2024-06-21 19:21:27.715630000 +0200
-@@ -18,7 +18,7 @@
+--- internal/sourceanalysis/go.go.orig	1979-11-29 23:00:00 UTC
++++ internal/sourceanalysis/go.go
+@@ -18,7 +18,7 @@ func goAnalysis(r reporter.Reporter, pkgs []models.Pac
  )
  
  func goAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.SourceInfo) {


### PR DESCRIPTION
This now requires Go 1.23.

Changelog:	https://github.com/google/osv-scanner/releases/tag/v1.9.1
Sponsored by:   The FreeBSD Foundation