### PR TITLE
Update pulseaudio to 17.0

### DIFF
--- a/audio/pulseaudio/Makefile
+++ b/audio/pulseaudio/Makefile
@@ -3,7 +3,7 @@
 # PORTREVISION bumps of depending ports.
 
 PORTNAME=	pulseaudio
-DISTVERSION=	16.1
+DISTVERSION=	17.0
 PORTREVISION=	4
 CATEGORIES=	audio
 MASTER_SITES=	https://freedesktop.org/software/pulseaudio/releases/
@@ -72,7 +72,7 @@ SPEEX_DESC=	Speex resampler and AEC support
 SPEEX_MESON_ENABLED=	speex
 SPEEX_LIB_DEPENDS=	libspeexdsp.so:audio/speexdsp
 WEBRTC_AEC_DESC=	WebRTC-based echo canceller
-WEBRTC_AEC_LIB_DEPENDS=	libwebrtc_audio_processing.so:audio/webrtc-audio-processing0
+WEBRTC_AEC_LIB_DEPENDS=	libwebrtc-audio-processing-1.so:audio/webrtc-audio-processing
 WEBRTC_AEC_MESON_ENABLED=	webrtc-aec
 
 OPTIONS_SINGLE=	DATABASE

--- a/audio/pulseaudio/distinfo
+++ b/audio/pulseaudio/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1691308577
-SHA256 (pulseaudio-16.1.tar.xz) = 8eef32ce91d47979f95fd9a935e738cd7eb7463430dabc72863251751e504ae4
-SIZE (pulseaudio-16.1.tar.xz) = 1545596
+TIMESTAMP = 1731932849
+SHA256 (pulseaudio-17.0.tar.xz) = 053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5
+SIZE (pulseaudio-17.0.tar.xz) = 1566556

--- a/audio/pulseaudio/files/patch-src_modules_echo-cancel_meson.build
+++ b/audio/pulseaudio/files/patch-src_modules_echo-cancel_meson.build
@@ -1,10 +1,10 @@
---- src/modules/echo-cancel/meson.build.orig	2022-06-21 10:54:48 UTC
+--- src/modules/echo-cancel/meson.build.orig	2024-01-12 17:22:09 UTC
 +++ src/modules/echo-cancel/meson.build
-@@ -15,7 +15,7 @@ libwebrtc_util = shared_library('webrtc-util',
+@@ -24,7 +24,7 @@ libwebrtc_util = shared_library('webrtc-util',
    cpp_args : [pa_c_args, server_c_args],
    include_directories : [configinc, topinc],
    dependencies : [libpulse_dep, libpulsecommon_dep, libpulsecore_dep, libatomic_ops_dep, webrtc_dep, libintl_dep],
--  link_args : [nodelete_link_args, '-Wl,--unresolved-symbols=ignore-in-object-files'],
+-  link_args : [nodelete_link_args, ignore_unresolved_symbols_link_args],
 +  link_args : [nodelete_link_args],
    install : true,
    install_rpath : privlibdir,

--- a/audio/pulseaudio/files/patch-src_modules_meson.build
+++ b/audio/pulseaudio/files/patch-src_modules_meson.build
@@ -1,6 +1,6 @@
---- src/modules/meson.build.orig	2022-06-21 10:54:48 UTC
+--- src/modules/meson.build.orig	2024-01-12 17:22:09 UTC
 +++ src/modules/meson.build
-@@ -209,7 +209,7 @@ endif
+@@ -221,7 +221,7 @@ endif
    ]
  endif
  

--- a/audio/pulseaudio/files/patch-src_modules_oss_module-oss.c
+++ b/audio/pulseaudio/files/patch-src_modules_oss_module-oss.c
@@ -1,4 +1,4 @@
---- src/modules/oss/module-oss.c.orig	2022-06-21 10:54:48 UTC
+--- src/modules/oss/module-oss.c.orig	2024-01-12 17:22:09 UTC
 +++ src/modules/oss/module-oss.c
 @@ -121,9 +121,6 @@ struct userdata {
      int fd;

--- a/audio/pulseaudio/files/patch-src_pulsecore_core-util.c
+++ b/audio/pulseaudio/files/patch-src_pulsecore_core-util.c
@@ -1,6 +1,6 @@
---- src/pulsecore/core-util.c.orig	2024-04-04 06:44:07 UTC
+--- src/pulsecore/core-util.c.orig	2024-01-12 17:22:09 UTC
 +++ src/pulsecore/core-util.c
-@@ -2849,12 +2849,19 @@ int pa_close_allv(const int except_fds[]) {
+@@ -2850,12 +2850,19 @@ int pa_close_allv(const int except_fds[]) {
      }
  
  #endif

--- a/audio/pulseaudio/pkg-plist
+++ b/audio/pulseaudio/pkg-plist
@@ -12,7 +12,7 @@ bin/pasuspender
 bin/pulseaudio
 bin/qpaeq
 %%X11%%bin/start-pulseaudio-x11
-etc/dbus-1/system.d/pulseaudio-system.conf
+share/dbus-1/system.d/pulseaudio-system.conf
 @sample etc/pulse/client.conf.sample
 @sample etc/pulse/daemon.conf.sample
 @sample etc/pulse/default.pa.sample
@@ -61,7 +61,7 @@ lib/libpulse-simple.so.0
 lib/libpulse-simple.so.0.1.1
 lib/libpulse.so
 lib/libpulse.so.0
-lib/libpulse.so.0.24.2
+lib/libpulse.so.0.24.3
 %%AVAHI%%lib/pulseaudio/modules/libavahi-wrap.so
 %%ALSA%%lib/pulseaudio/modules/libalsa-util.so
 lib/pulseaudio/modules/libcli.so

--- a/multimedia/pipewire/Makefile
+++ b/multimedia/pipewire/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	pipewire
 DISTVERSION=	1.2.6
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	multimedia
 
 MAINTAINER=	arrowd@FreeBSD.org
@@ -17,7 +17,7 @@ LIB_DEPENDS=	libdbus-1.so:devel/dbus \
 		libopus.so:audio/opus \
 		libsndfile.so:audio/libsndfile \
 		libudev.so:devel/libudev-devd \
-		libwebrtc_audio_processing.so:audio/webrtc-audio-processing0
+		libwebrtc-audio-processing-1.so:audio/webrtc-audio-processing
 
 USES=		compiler:c11 gettext-tools gnome localbase:ldflags meson \
 		ncurses pkgconfig python:build readline shebangfix ssl


### PR DESCRIPTION
The new pulseaudio requires webrtc-audio-processing-1.3. Updated the webrtc version in pipe wire.
