### PR TITLE
Fix glusterfs

### DIFF
--- a/net/glusterfs/Makefile
+++ b/net/glusterfs/Makefile
@@ -13,10 +13,7 @@ LICENSE_COMB=	dual
 LICENSE_FILE_GPLv2=	${WRKSRC}/COPYING-GPLV2
 LICENSE_FILE_LGPL3+ =	${WRKSRC}/COPYING-LGPLV3
 
-BROKEN=		Fails to build, ld: error: version script assignment of 'global' to symbol 'client_dump' failed: symbol not defined
-DEPRECATE=	Outdated and unsupported upstream, current version in tree was released in 2021 while upstream is still active and is at 10.x
-EXPIRATION_DATE=2025-01-31
-#BROKEN_SSL=	libressl
+BROKEN_SSL=	libressl
 
 BUILD_DEPENDS=	bash:shells/bash
 RUN_DEPENDS=	bash:shells/bash
@@ -73,6 +70,7 @@ CONFIGURE_ARGS=	--disable-epoll \
 		ac_cv_lib_aio_io_setup=no
 CPPFLAGS+=	-I"${LOCALBASE}/include"
 LDFLAGS+=	-L"${LOCALBASE}/lib" -largp
+LDFLAGS+=	-Wl,--undefined-version
 INSTALL_TARGET=	install-strip
 PLIST_SUB=	GLUSTERLIBDIR="lib/${PORTNAME}" \
 		PORTVERSION="${PORTVERSION}"


### PR DESCRIPTION
Revert the "broken" status for GlusterFS and add an extra LDFLAGS line that allows the port to compile and run as expected.

I'm actively using this and have been using it for a few weeks now on FreeBSD 14.1.

I'll also start looking into updating the port to a more recent upstream version of GlusterFS.