### PR TITLE
turbo/pkg-message: x11/xsel abandonware in 2019

### DIFF
--- a/editors/turbo/pkg-message
+++ b/editors/turbo/pkg-message
@@ -3,8 +3,8 @@
   message: <<EOM
 The runtime requirements are (please install at your preference):
 
-* `xsel' or `xclip' for clipboard support in X11 environments
-* `wl-clipboard' for clipboard support in Wayland environments
+* `x11/xclip' or `x11/xsel-conrad' for clipboard support in X.Org environments
+* `x11/wl-clipboard' for clipboard support in Wayland environments
 EOM
 }
 ]


### PR DESCRIPTION
https://mail-archive.freebsd.org/cgi/mid.cgi?201905081934.x48JYG8a039255 included:

2019-05-08 x11/xsel: Abandonware; use x11/xsel-conrad instead

Whilst here: X.Org instead of X11; add categories; and alphabetical
order for the two ports in the first bullet point.