### PR TITLE
misc/vxl: remove conflict between build conflicts

### DIFF
--- a/misc/vxl/Makefile
+++ b/misc/vxl/Makefile
@@ -20,11 +20,10 @@ USE_GITHUB=	yes
 USE_LDCONFIG=	yes
 
 CONFLICTS_BUILD=	openjpeg15
+CONFLICTS_BUILD+=	dcmtk # because it is bundled
 
 CMAKE_ON=	BUILD_SHARED_LIBS
 CMAKE_OFF=	BUILD_TESTING
-
-CONFLICTS_BUILD=	dcmtk # because it is bundled
 
 do-test: # 1 test fails, see https://github.com/vxl/vxl/issues/920
 	@cd ${BUILD_WRKSRC} && \


### PR DESCRIPTION
The port Makefile had 2 conflicting lines that specify CONFLICTS_BUILD
twice overriding one another. Thus effectively only the dcmtk block is 
effective. 

misc/vxl $ grep ^CONFLICT Makefile
CONFLICTS_BUILD=   openjpeg15
CONFLICTS_BUILD=   dcmtk # because it is bundled