### PR TITLE
sysutils/podman-compose: add port

### DIFF
--- a/sysutils/podman-compose/Makefile
+++ b/sysutils/podman-compose/Makefile
@@ -1,0 +1,25 @@
+PORTNAME=	podman-compose
+PORTVERSION=	1.3.0
+CATEGORIES=	sysutils python
+MASTER_SITES=	PYPI
+DISTNAME=       podman_compose-${DISTVERSION}
+
+MAINTAINER=	getz@FreeBSD.org
+COMMENT=	Script to run docker-compose.yml using podman
+WWW=		https://github.com/containers/podman-compose
+
+LICENSE=	GPLv2
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pyyaml>=0:devel/py-pyyaml@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}python-dotenv>=0:www/py-python-dotenv@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}wheel>=0:devel/py-wheel@${PY_FLAVOR}
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pyyaml>=0:devel/py-pyyaml@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}python-dotenv>=0:www/py-python-dotenv@${PY_FLAVOR}
+
+USES=		python
+USE_PYTHON=	autoplist concurrent pep517
+
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/sysutils/podman-compose/distinfo
+++ b/sysutils/podman-compose/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1738676930
+SHA256 (podman_compose-1.3.0.tar.gz) = e65a70e8fa26bd195d2017ac5893149b40c0df5a0c20d480a338c4f60218b1fa
+SIZE (podman_compose-1.3.0.tar.gz) = 42258

--- a/sysutils/podman-compose/pkg-descr
+++ b/sysutils/podman-compose/pkg-descr
@@ -1,0 +1,4 @@
+podman-compose is a tool for running docker-compose.yml using podman.
+With Compose, you use a Compose file to configure your application's services.
+Then, using a single command, you create and start all the services from your
+configuration.


### PR DESCRIPTION
This tool is used to run docker-compose.yml using podman. 
It's an implementation of Compose Spec with Podman backend.

I have tested it on 14.2-RELEASE and ran portlint and poudriere testport.
I opted to name it podman-compose instead of using `PKGNAMEPREFIX= ${PYTHON_PKGNAMEPREFIX}` as it's just a program to run and its language is not important to users.