### PR TITLE
x11-drivers/xf86-video-intel: tools compile fix

### DIFF
--- a/x11-drivers/xf86-video-intel/files/patch-tools__virtual.c
+++ b/x11-drivers/xf86-video-intel/files/patch-tools__virtual.c
@@ -1,0 +1,13 @@
+--- tools/virtual.c.orig	2023-02-01 18:07:58 UTC
++++ tools/virtual.c
+@@ -69,6 +69,10 @@
+ #include <fcntl.h>
+ #include <assert.h>
+ 
++#ifndef ETIME
++#define ETIME ETIMEDOUT
++#endif
++
+ #define FORCE_FULL_REDRAW 0
+ #define FORCE_16BIT_XFER 0
+ 


### PR DESCRIPTION
Conditionally define ETIME to address compile breakage reported as PR #277510 [1]

PR:             277510 [1]
Reported by:    o.hartmann [1]