### PR TITLE
lang/dotnet8: Fix build after the LLVM_DEFAULT bump

### DIFF
--- a/lang/dotnet8/Makefile
+++ b/lang/dotnet8/Makefile
@@ -31,7 +31,7 @@ LIB_DEPENDS=	libicuuc.so:devel/icu \
 RUN_DEPENDS=	terminfo-db>0:misc/terminfo-db \
 		dotnet:lang/dotnet-runtime
 
-USES=		autoreconf:build gssapi:mit llvm:noexport nodejs pkgconfig \
+USES=		autoreconf:build gssapi:mit llvm:noexport,max=17 nodejs pkgconfig \
 		python:build,3.9+ shebangfix ssl
 
 USE_GITHUB=	yes


### PR DESCRIPTION
PR:		285085

Applied current fix in main to 2025Q1 as dotnet8 is currently broken without it.