### PR TITLE
graphics/drm-66-kmod for 1500031 and above

### DIFF
--- a/graphics/drm-66-kmod/pkg-descr
+++ b/graphics/drm-66-kmod/pkg-descr
@@ -1,4 +1,4 @@
 amdgpu, i915, and radeon DRM drivers modules.
 Currently corresponding to Linux 6.6 DRM.
-This version is for FreeBSD 15 1500023
+This version is for FreeBSD 15 1500031
 and above.


### PR DESCRIPTION
Consistency: 1500031, not 1500023.