### PR TITLE
x11/kde-gear/Makefile: fix spelling

### DIFF
--- a/x11/kde-gear/Makefile
+++ b/x11/kde-gear/Makefile
@@ -3,7 +3,7 @@ PORTVERSION=	${KDE_APPLICATIONS_VERSION}
 CATEGORIES=	x11 kde
 
 MAINTAINER=	kde@FreeBSD.org
-COMMENT=	KDE Gear distribuition (meta port)
+COMMENT=	KDE Gear distribution (meta port)
 WWW=		https://apps.kde.org/
 
 USES=		kde:6 metaport qt:6


### PR DESCRIPTION
Distribution, not distribuition.

Fixes: 7fe25b0d97da