### PR TITLE
databases/prometheus-postgres-exporter: update to 0.17.1

### DIFF
--- a/databases/prometheus-postgres-exporter/Makefile
+++ b/databases/prometheus-postgres-exporter/Makefile
@@ -1,10 +1,9 @@
 PORTNAME=	prometheus-postgres-exporter
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.16.0
-PORTREVISION=	2
+DISTVERSION=	0.17.1
 CATEGORIES=	databases
 
-MAINTAINER=	lexi@hemlock.eden.le-fay.org
+MAINTAINER=	ivy@FreeBSD.org
 COMMENT=	PostgreSQL metric exporter for Prometheus
 WWW=		https://github.com/prometheus-community/postgres_exporter
 

--- a/databases/prometheus-postgres-exporter/distinfo
+++ b/databases/prometheus-postgres-exporter/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1731341402
-SHA256 (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.16.0/v0.16.0.mod) = e16051bb4c30828066f28f893adb575164484a0a3ac2740c089a99057e22c0b1
-SIZE (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.16.0/v0.16.0.mod) = 1805
-SHA256 (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.16.0/v0.16.0.zip) = 1246fbf68c0a81929ca97f4967dfabaab40604c216917a7073f5904e282b7d05
-SIZE (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.16.0/v0.16.0.zip) = 156127
+TIMESTAMP = 1742500888
+SHA256 (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.17.1/v0.17.1.mod) = d4e5283cf7e96aaabff30962deb272e2566fa9cd9bbf8f8de2d0979bcb5e3a84
+SIZE (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.17.1/v0.17.1.mod) = 1806
+SHA256 (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.17.1/v0.17.1.zip) = d7e49ae1f9488cd3195dee4b99dd39981dc13dd7118aa323029d90dfb8c46cca
+SIZE (go/databases_prometheus-postgres-exporter/prometheus-postgres-exporter-v0.17.1/v0.17.1.zip) = 160921


### PR DESCRIPTION
new upstream release; this adds support for PostgreSQL 17.

changes in 0.17.0:

* [ENHANCEMENT] Add Postgres 17 for CI test by @khiemdoan in #1105
* [ENHANCEMENT] Add wait/backend to pg_stat_activity by @fgalind1 in #1106
* [ENHANCEMENT] Export last replay age in replication collector by @bitfehler in #1085
* [BUGFIX] Fix pg_long_running_transactions time by @jyothikirant-sayukth in #1092
* [BUGFIX] Fix to replace dashes with underscore in the metric names by @aagarwalla-fx in #1103
* [BUGFIX] Checkpoint related columns in PG 17 have been moved from pg_stat_bgwriter to pg_stat_checkpointer by @n-rodriguez in #1072
* [BUGFIX] Fix pg_stat_statements for PG17 by @NevermindZ4 in #1114
* [BUGFIX] Handle pg_replication_slots on pg<13 by @michael-todorovic in #1098
* [BUGFIX] Fix missing dsn sanitization for logging by @sysadmind in #1104

changes in 0.17.1:

[BUGFIX] Fix: Handle incoming labels with invalid UTF-8 #1131