### PR TITLE
Gecko browsers: remove TCP Fast Open missing remarks

### DIFF
--- a/www/firefox-esr/pkg-message
+++ b/www/firefox-esr/pkg-message
@@ -10,7 +10,6 @@ Some features found on Windows, macOS and Linux are not implemented:
 - Reduced memory usage (requires mozjemalloc)
 - Crash Reporter (requires Google Breakpad and reproducible builds)
 - WebVR (requires open source runtime)
-- TCP fast open
 - `about:networking#networkid` (requires link state notification)
 
 ## Audio backend

--- a/www/firefox/pkg-message
+++ b/www/firefox/pkg-message
@@ -10,7 +10,6 @@ Some features found on Windows, macOS and Linux are not implemented:
 - Reduced memory usage (requires mozjemalloc)
 - Crash Reporter (requires Google Breakpad and reproducible builds)
 - WebVR (requires open source runtime)
-- TCP fast open
 - `about:networking#networkid` (requires link state notification)
 
 ## Audio backend

--- a/www/librewolf/pkg-message
+++ b/www/librewolf/pkg-message
@@ -10,7 +10,6 @@ Some features found on Windows, macOS and Linux are not implemented:
 - Reduced memory usage (requires mozjemalloc)
 - Crash Reporter (requires Google Breakpad and reproducible builds)
 - WebVR (requires open source runtime)
-- TCP fast open
 - `about:networking#networkid` (requires link state notification)
 
 ## Audio backend

--- a/www/waterfox/pkg-message
+++ b/www/waterfox/pkg-message
@@ -10,7 +10,6 @@ Some features found on Windows, macOS and Linux are not implemented:
 - Reduced memory usage (requires mozjemalloc)
 - Crash Reporter (requires Google Breakpad and reproducible builds)
 - WebVR (requires open source runtime)
-- TCP fast open
 - `about:networking` (requires link state notification)
 
 ## Audio backend


### PR DESCRIPTION
Support for client side RFC 7413 has been in base since version 12 (see: c560df6f12 and af4da58655).

Meanwhile Mozilla eventually decided to remove the TFO implementation in Firefox 87 around 2021
(ref.: https://bugzilla.mozilla.org/show_bug.cgi?id=1689604).