### PR TITLE
x11-wm/enlightenment: add options to build without Pulseaudio and with EFM mount/unmount support

### DIFF
--- a/x11-wm/enlightenment/Makefile
+++ b/x11-wm/enlightenment/Makefile
@@ -11,8 +11,7 @@ WWW=		https://www.enlightenment.org/
 
 LICENSE=	BSD2CLAUSE
 
-LIB_DEPENDS=	libefl.so:devel/efl \
-		libpulse.so:audio/pulseaudio
+LIB_DEPENDS=	libefl.so:devel/efl
 
 USES=		compiler:c11 cpe desktop-file-utils gettext-tools gnome \
 		localbase:ldflags meson ninja iconv libtool pathfix pkgconfig \
@@ -25,17 +24,24 @@ MESON_ARGS=	-Dsystemd=false -Ddevice-udev=false \
 		-Dmount-udisks=false -Dmount-eeze=false -Dbluez5=false \
 		-Delput=false -Dgesture-recognition=false
 
-OPTIONS_DEFINE=		NLS EXIF
-OPTIONS_DEFAULT=	NLS EXIF
+OPTIONS_DEFINE=		NLS EXIF MIXER MOUNT
+OPTIONS_DEFAULT=	NLS EXIF MIXER
 OPTIONS_SUB=		yes
 
 EXIF_DESC=		Exif metadata display support
+MIXER_DESC=		Build Mixer module (needs Pulseaudio and EFL support of Pulseaudio)
+MOUNT_DESC=		Volumes mount support in EFM (needs Bsdisks, experimental)
 
 NLS_USES=		gettext-runtime
 NLS_MESON_TRUE=		nls
 
 EXIF_LIB_DEPENDS=	libexif.so:graphics/libexif
 EXIF_MESON_TRUE=	libexif
+
+MIXER_MESON_TRUE=	mixer
+MIXER_LIB_DEPENDS=	libpulse.so:audio/pulseaudio
+
+MOUNT_RUN_DEPENDS=	bsdisks:sysutils/bsdisks
 
 # MESON normalizes ${ARCH} so we cannot use it 'AS IS' without conversion
 CURRENT_ARCH=	${ARCH}

--- a/x11-wm/enlightenment/pkg-plist
+++ b/x11-wm/enlightenment/pkg-plist
@@ -1,4 +1,4 @@
-bin/emixer
+%%MIXER%%bin/emixer
 bin/enlightenment
 bin/enlightenment_askpass
 bin/enlightenment_filemanager
@@ -273,10 +273,10 @@ lib/enlightenment/modules/ibox/e-module-ibox.edj
 lib/enlightenment/modules/ibox/%%ENLIGHTENMENT_ARCH%%/module.so
 lib/enlightenment/modules/ibox/module.desktop
 lib/enlightenment/modules/lokker/%%ENLIGHTENMENT_ARCH%%/module.so
-lib/enlightenment/modules/mixer/e-module-mixer.edj
-lib/enlightenment/modules/mixer/%%ENLIGHTENMENT_ARCH%%/module.so
-lib/enlightenment/modules/mixer/module.desktop
-lib/enlightenment/modules/mixer/sink-icons.txt
+%%MIXER%%lib/enlightenment/modules/mixer/e-module-mixer.edj
+%%MIXER%%lib/enlightenment/modules/mixer/%%ENLIGHTENMENT_ARCH%%/module.so
+%%MIXER%%lib/enlightenment/modules/mixer/module.desktop
+%%MIXER%%lib/enlightenment/modules/mixer/sink-icons.txt
 lib/enlightenment/modules/msgbus/e-module-msgbus.edj
 lib/enlightenment/modules/msgbus/%%ENLIGHTENMENT_ARCH%%/module.so
 lib/enlightenment/modules/msgbus/module.desktop
@@ -391,7 +391,7 @@ lib/enlightenment/utils/enlightenment_sys
 lib/enlightenment/utils/enlightenment_system
 lib/enlightenment/utils/enlightenment_thumb
 lib/enlightenment/utils/enlightenment_wallpaper_gen
-share/applications/emixer.desktop
+%%MIXER%%share/applications/emixer.desktop
 share/applications/enlightenment_askpass.desktop
 share/applications/enlightenment_filemanager.desktop
 share/applications/enlightenment_fprint.desktop
@@ -582,7 +582,7 @@ share/applications/enlightenment_paledit.desktop
 %%DATADIR%%/doc/illume2.html
 %%DATADIR%%/doc/illume2.png
 %%DATADIR%%/themes/enlightenment_fprint.edj
-share/icons/hicolor/128x128/apps/emixer.png
+%%MIXER%%share/icons/hicolor/128x128/apps/emixer.png
 share/icons/hicolor/128x128/apps/enlightenment_fprint.png
 share/icons/hicolor/128x128/apps/enlightenment_paledit.png
 share/icons/hicolor/512x512/apps/enlightenment.png


### PR DESCRIPTION
@arrowd 
Please, merge