### PR TITLE
security/vuxml: fix clumsy whitespace use

### DIFF
--- a/security/vuxml/vuln/2025.xml
+++ b/security/vuxml/vuln/2025.xml
@@ -47,7 +47,7 @@
 	<body xmlns="http://www.w3.org/1999/xhtml">
     <p>h11 reports:</p>
     <blockquote cite="https://github.com/python-hyper/h11/security/advisories/GHSA-vqfr-h8mv-ghfj">
-      <p>h11 is a Python implementation of HTTP/1.1. Prior to version 0.16.0, a leniency in h11's parsing of line t  erminators in chunked-coding message bodies can lead to request smuggling vulnerabilities under certain conditions. This issu  e has been patched in version 0.16.0. Since exploitation requires the combination of buggy h11 with a buggy (reverse) proxy,   fixing either component is sufficient to mitigate this issue.</p>
+      <p>h11 is a Python implementation of HTTP/1.1. Prior to version 0.16.0, a leniency in h11's parsing of line terminators in chunked-coding message bodies can lead to request smuggling vulnerabilities under certain conditions. This issue has been patched in version 0.16.0. Since exploitation requires the combination of buggy h11 with a buggy (reverse) proxy, fixing either component is sufficient to mitigate this issue.</p>
 	</blockquote>
 	</body>
     </description>


### PR DESCRIPTION
This text was added in 72eea8b with words split in half.