### PR TITLE
Uses/cargo: use --locked flag on install

### DIFF
--- a/Mk/Uses/cargo.mk
+++ b/Mk/Uses/cargo.mk
@@ -341,6 +341,7 @@ do-build:
 do-install:
 .    for path in ${CARGO_INSTALL_PATH}
 	@${CARGO_CARGO_RUN} install \
+		--locked \
 		--no-track \
 		--path "${path}" \
 		--root "${STAGEDIR}${PREFIX}" \


### PR DESCRIPTION
By default cargo install ignores the lock file [1]. This will cause our
build to fail easily. First of all, when building with tools like
poudriere, network access will be disabled in install stage. Fetching a
new crate won't be possible. Additionally, a newer crate version might
be incompatible with our crate or even more worse unbuildable at all.
For that reason, force cargo to honor the lock file on install.

[1] https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile

Sponsored by:		Beckhoff Automation GmbH & Co. KG