### PR TITLE
devel/py-structlog: update to 25.3.0

### DIFF
--- a/devel/py-structlog/Makefile
+++ b/devel/py-structlog/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	structlog
-PORTVERSION=	18.2.0
-PORTREVISION=	1
+PORTVERSION=	25.3.0
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -11,14 +10,17 @@ WWW=		https://www.structlog.org/
 
 LICENSE=	APACHE20 MIT
 LICENSE_COMB=	dual
-LICENSE_FILE_APACHE20=	${WRKSRC}/LICENSE.apache2
-LICENSE_FILE_MIT=	${WRKSRC}/LICENSE.mit
+LICENSE_FILE_APACHE20=	${WRKSRC}/LICENSE-APACHE
+LICENSE_FILE_MIT=	${WRKSRC}/LICENSE-MIT
 
-RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}colorama>=0.3.3:devel/py-colorama@${PY_FLAVOR} \
-			${PYTHON_PKGNAMEPREFIX}six>=1.10.0:devel/py-six@${PY_FLAVOR}
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}hatch-fancy-pypi-readme>0:devel/py-hatch-fancy-pypi-readme@${PY_FLAVOR} \
+	${PYTHON_PKGNAMEPREFIX}hatch-vcs>=0:devel/py-hatch-vcs@${PY_FLAVOR} \
+	${PYTHON_PKGNAMEPREFIX}hatchling>=0:devel/py-hatchling@${PY_FLAVOR} \
+
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}typing-extensions>=4.12.2:devel/py-typing-extensions@${PY_FLAVOR}
 
 NO_ARCH=	yes
 USES=		python
-USE_PYTHON=	autoplist distutils
+USE_PYTHON=	autoplist concurrent pep517
 
 .include <bsd.port.mk>

--- a/devel/py-structlog/distinfo
+++ b/devel/py-structlog/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1563985335
-SHA256 (structlog-18.2.0.tar.gz) = e361edb3b9aeaa85cd38a1bc9ddbb60cda8a991fc29de9db26832f6300e81eb4
-SIZE (structlog-18.2.0.tar.gz) = 316679
+TIMESTAMP = 1746395007
+SHA256 (structlog-25.3.0.tar.gz) = 8dab497e6f6ca962abad0c283c46744185e0c9ba900db52a423cb6db99f7abeb
+SIZE (structlog-25.3.0.tar.gz) = 1367514


### PR DESCRIPTION
Reported by: bofh

This is a test PR to see if we can auto-close a github PR, where
the diff/patch has been committed via committer to FreeBSD ports
tree, but with modifications.