### PR TITLE
Fixes issue in security/tpm2-tss trying to access /dev/tpmrm0

### DIFF
--- a/security/tpm2-tss/files/patch-src_tss2-esys_esys__context.c
+++ b/security/tpm2-tss/files/patch-src_tss2-esys_esys__context.c
@@ -1,0 +1,11 @@
+--- src/tss2-esys/esys_context.c.orig	2025-02-22 22:43:21 UTC
++++ src/tss2-esys/esys_context.c
+@@ -26,7 +26,7 @@
+  * If not specified, load a TCTI in this order:
+  *       Library libtss2-tcti-default.so (link to the preferred TCTI)
+  *       Library libtss2-tcti-tabrmd.so (tabrmd)
+- *       Device /dev/tpmrm0 (kernel resident resource manager)
++ *       Device /dev/tpmrm0 (kernel resident resource manager, SKIPPED on FreeBSD)
+  *       Device /dev/tpm0 (hardware TPM)
+  *       TCP socket localhost:2321 (TPM simulator)
+  * @param esys_context [out] The ESYS_CONTEXT.

--- a/security/tpm2-tss/files/patch-src_tss2-tcti_tcti-device.c
+++ b/security/tpm2-tss/files/patch-src_tss2-tcti_tcti-device.c
@@ -1,0 +1,11 @@
+--- src/tss2-tcti/tcti-device.c.orig	2025-02-22 22:43:21 UTC
++++ src/tss2-tcti/tcti-device.c
+@@ -58,7 +58,7 @@ static char *default_conf[] = {
+ #include "util/log.h"
+ 
+ static char *default_conf[] = {
+-#ifdef __VXWORKS__
++#if defined(__VXWORKS__) || defined(__FreeBSD__)
+     "/dev/tpm0"
+ #else
+     "/dev/tpmrm0",

--- a/security/tpm2-tss/files/patch-src_tss2-tcti_tcti-device.c
+++ b/security/tpm2-tss/files/patch-src_tss2-tcti_tcti-device.c
@@ -1,11 +1,12 @@
---- src/tss2-tcti/tcti-device.c.orig	2025-02-22 22:43:21 UTC
-+++ src/tss2-tcti/tcti-device.c
-@@ -58,7 +58,7 @@ static char *default_conf[] = {
- #include "util/log.h"
- 
- static char *default_conf[] = {
--#ifdef __VXWORKS__
-+#if defined(__VXWORKS__) || defined(__FreeBSD__)
-     "/dev/tpm0"
+--- src/tss2-tcti/tcti-device.c.orig	2023-01-23 18:36:16.000000000 +0000
++++ src/tss2-tcti/tcti-device.c	2025-05-08 08:40:29.255475000 +0000
+@@ -61,7 +61,9 @@
+ #ifdef __VXWORKS__
+     "/tpm0"
  #else
++#ifndef __FreeBSD__
      "/dev/tpmrm0",
++#endif /* __FreeBSD__ */
+     "/dev/tpm0",
+ #endif /* __VX_WORKS__ */
+ };

--- a/security/tpm2-tss/files/patch-src_tss2-tcti_tctildr-dl.c
+++ b/security/tpm2-tss/files/patch-src_tss2-tcti_tctildr-dl.c
@@ -1,0 +1,16 @@
+--- src/tss2-tcti/tctildr-dl.c.orig	2025-02-22 22:43:21 UTC
++++ src/tss2-tcti/tctildr-dl.c
+@@ -37,11 +37,13 @@ struct {
+         .file = "libtss2-tcti-tabrmd.so.0",
+         .description = "Access libtss2-tcti-tabrmd.so",
+     },
++#if !defined(__FreeBSD__)
+     {
+         .file = "libtss2-tcti-device.so.0",
+         .conf = "/dev/tpmrm0",
+         .description = "Access libtss2-tcti-device.so.0 with /dev/tpmrm0",
+     },
++#endif
+     {
+         .file = "libtss2-tcti-device.so.0",
+         .conf = "/dev/tpm0",

--- a/security/tpm2-tss/files/patch-src_tss2-tcti_tctildr-nodl.c
+++ b/security/tpm2-tss/files/patch-src_tss2-tcti_tctildr-nodl.c
@@ -1,0 +1,11 @@
+--- src/tss2-tcti/tctildr-nodl.c.orig	2025-02-22 22:43:21 UTC
++++ src/tss2-tcti/tctildr-nodl.c
+@@ -67,7 +67,7 @@ struct {
+         .init = Tss2_Tcti_Tbs_Init,
+         .description = "Access to TBS",
+     },
+-#elif defined (__VXWORKS__)
++#elif defined (__VXWORKS__) || defined(__FreeBSD__)
+     {
+         .names = {
+             "libtss2-tcti-device.so.0",

--- a/security/tpm2-tss/files/patch-test_unit_tctildr-nodl.c
+++ b/security/tpm2-tss/files/patch-test_unit_tctildr-nodl.c
@@ -1,0 +1,14 @@
+--- test/unit/tctildr-nodl.c.orig	2025-02-22 22:43:21 UTC
++++ test/unit/tctildr-nodl.c
+@@ -65,9 +65,11 @@ test_tctildr_get_default_all_fail (void **state)
+     /* device:/dev/tpm0 */
+     will_return (__wrap_tcti_from_init, tcti_ctx);
+     will_return (__wrap_tcti_from_init, TEST_RC);
++#if !defined (__FreeBSD__)
+     /* device:/dev/tpmrm0 */
+     will_return (__wrap_tcti_from_init, tcti_ctx);
+     will_return (__wrap_tcti_from_init, TEST_RC);
++#endif
+     /* swtpm */
+     will_return (__wrap_tcti_from_init, tcti_ctx);
+     will_return (__wrap_tcti_from_init, TEST_RC);


### PR DESCRIPTION
FreeBSD does not have an in-kernel Resource Manager for TPM, the tools must access the /dev/tpm0 device, either directly or through an userland RM like tpm2-abrmd.

The default behavior of the original code is to try the in kernel RM on /dev/tpmrm0 as first choice, this causes warnings and errors and forces the user to override the behavior with options or environment variables.

This patch removes the attempt to use /dev/tpmrm0 so that the programs "just work" using the tpm0 device or through tpm2-abrmd.