### PR TITLE
[NEW PORT] security/tpm2-openssl TPM2 provider for OpenSSL3+

### DIFF
--- a/security/tpm2-openssl/Makefile
+++ b/security/tpm2-openssl/Makefile
@@ -13,11 +13,21 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 LIB_DEPENDS=    libtss2-esys.so:security/tpm2-tss
 RUN_DEPENDS=    tpm2-abrmd:security/tpm2-abrmd
 
-USES=		gmake libtool pkgconfig
+USES=		gmake libtool pkgconfig ssl
 USE_LDCONFIG=	yes
 
 GNU_CONFIGURE=	yes
 
+.include <bsd.port.pre.mk>
+
+.if "${OPENSSLLIB}" == /usr/lib
+post-install:
+	${MKDIR} -p ${STAGEDIR}${PREFIX}/lib/ossl-modules
+	${MV} ${STAGEDIR}/usr/lib/ossl-modules/tpm2.so ${STAGEDIR}${PREFIX}/lib/ossl-modules
+.endif
+
 INSTALL_TARGET=	install-strip
 
-.include <bsd.port.mk>
+PLIST_FILES=	lib/ossl-modules/tpm2.so
+
+.include <bsd.port.post.mk>

--- a/security/tpm2-openssl/Makefile
+++ b/security/tpm2-openssl/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	tpm2-openssl
 DISTVERSION=	1.3.0
-PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	https://github.com/tpm2-software/tpm2-openssl/releases/download/${DISTVERSION}/
 

--- a/security/tpm2-openssl/Makefile
+++ b/security/tpm2-openssl/Makefile
@@ -1,0 +1,27 @@
+PORTNAME=	tpm2-openssl
+DISTVERSION=	1.3.0
+PORTREVISION=	1
+CATEGORIES=	security
+MASTER_SITES=	https://github.com/tpm2-software/tpm2-openssl/releases/download/${DISTVERSION}/
+
+MAINTAINER=	blackye@gmail.com
+COMMENT=	Provider for integration of TPM 2.0 into OpenSSL 3.x
+WWW=		https://github.com/tpm2-software/tpm2-openssl
+
+LICENSE=	BSD3CLAUSE
+
+LIB_DEPENDS=    libtss2-esys.so:security/tpm2-tss
+RUN_DEPENDS=    tpm2-abrmd:security/tpm2-abrmd
+
+USES=		gmake libtool pkgconfig
+USE_LDCONFIG=	yes
+
+GNU_CONFIGURE=	yes
+GNU_CONFIGURE_PREFIX=/usr/local
+GNU_CONFIGURE_LIBPREFIX=${PREFIX}/lib
+GNU_CONFIGURE_MANPREFIX=${PREFIX}/share
+
+INSTALL_TARGET=	install-strip
+
+
+.include <bsd.port.mk>

--- a/security/tpm2-openssl/Makefile
+++ b/security/tpm2-openssl/Makefile
@@ -8,6 +8,7 @@ COMMENT=	Provider for integration of TPM 2.0 into OpenSSL 3.x
 WWW=		https://github.com/tpm2-software/tpm2-openssl
 
 LICENSE=	BSD3CLAUSE
+LICENSE_FILE=	${WRKSRC}/LICENSE
 
 LIB_DEPENDS=    libtss2-esys.so:security/tpm2-tss
 RUN_DEPENDS=    tpm2-abrmd:security/tpm2-abrmd
@@ -16,11 +17,7 @@ USES=		gmake libtool pkgconfig
 USE_LDCONFIG=	yes
 
 GNU_CONFIGURE=	yes
-GNU_CONFIGURE_PREFIX=/usr/local
-GNU_CONFIGURE_LIBPREFIX=${PREFIX}/lib
-GNU_CONFIGURE_MANPREFIX=${PREFIX}/share
 
 INSTALL_TARGET=	install-strip
-
 
 .include <bsd.port.mk>

--- a/security/tpm2-openssl/distinfo
+++ b/security/tpm2-openssl/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1737838478
+SHA256 (tpm2-openssl-1.3.0.tar.gz) = 9a9aca55d4265ec501bcf9c56d21d6ca18dba902553f21c888fe725b42ea9964
+SIZE (tpm2-openssl-1.3.0.tar.gz) = 432730

--- a/security/tpm2-openssl/pkg-descr
+++ b/security/tpm2-openssl/pkg-descr
@@ -1,0 +1,1 @@
+Provider for integration of TPM 2.0 to OpenSSL 3.x

--- a/security/tpm2-openssl/pkg-message
+++ b/security/tpm2-openssl/pkg-message
@@ -14,7 +14,7 @@ following:
 
 [provider_sect]
 default = default_sect
-tpm2provider = tpm2_sect
+tpm2 = tpm2_sect
 
 [default_sect]
 activate = 1
@@ -26,4 +26,3 @@ module = ${PREFIX}/lib/ossl-modules/tpm2.so
 EOM
 }
 ]
-

--- a/security/tpm2-openssl/pkg-message
+++ b/security/tpm2-openssl/pkg-message
@@ -1,0 +1,29 @@
+[
+{ type: install
+  message: <<EOM
+The tpm2 provider has been installed as ${PREFIX}/lib/ossl-modules/tpm2.so.
+
+In order to let openssl find it you might want to move it to the directory
+/usr/lib/ossl-modules, otherwise  openssl will find it if you do one of the 
+following:
+
+1. set the OPENSSL_MODULES environment variable 
+2. use the -provider-path option
+3. edit /etc/ssl/openssl.cnf replacing the existing [provider_sect] and 
+   [default_provider] sections with these:
+
+[provider_sect]
+default = default_sect
+tpm2provider = tpm2_sect
+
+[default_sect]
+activate = 1
+
+[tpm2_sect]
+activate = 1
+module = ${PREFIX}/lib/ossl-modules/tpm2.so
+
+EOM
+}
+]
+

--- a/security/tpm2-openssl/pkg-plist
+++ b/security/tpm2-openssl/pkg-plist
@@ -1,1 +1,0 @@
-/usr/lib/ossl-modules/tpm2.so

--- a/security/tpm2-openssl/pkg-plist
+++ b/security/tpm2-openssl/pkg-plist
@@ -1,0 +1,1 @@
+/usr/lib/ossl-modules/tpm2.so


### PR DESCRIPTION
Makes the TPM 2.0 accessible via the standard OpenSSL API and command-line tools, so one can add TPM support to (almost) any OpenSSL 3.x based application.

This has been tested both with OpenSSL 3.0.16 and OpenSSL 3.5.0.
