### PR TITLE
up-go: new port

### DIFF
--- a/net-mgmt/up-go/Makefile
+++ b/net-mgmt/up-go/Makefile
@@ -1,0 +1,27 @@
+PORTNAME=	up-go
+DISTVERSIONPREFIX=	v
+DISTVERSION=	${MODVERSION:S/-/./g}
+CATEGORIES=	net-mgmt
+
+MAINTAINER=	hoanga@gmail.com
+COMMENT=	Troubleshoot problems with your Internet connection
+WWW=		https://github.com/jesusprubio/up
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE.txt
+
+USES=	go:modules
+MODVERSION=	1.3.0
+GO_MODULE=	github.com/jesusprubio/up@v${MODVERSION}
+GO_BUILDFLAGS+=	-ldflags "-s -w"
+CGO_ENABLED=	0
+GO_PKGNAME=	github.com/jesusprubio/${PORTNAME}
+GO_TARGET=	:${BIN_NAME}
+
+CONFLICTS_INSTALL=	up # bin/up
+
+PLIST_FILES=	bin/${BIN_NAME}
+
+BIN_NAME=	up
+
+.include <bsd.port.mk>

--- a/net-mgmt/up-go/distinfo
+++ b/net-mgmt/up-go/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1747169899
+SHA256 (go/net-mgmt_up-go/up-go-v1.3.0/v1.3.0.mod) = e33e43eeb7c20db22eb769d84c9cd614b11d7050592c5af7a4440a316b6292b2
+SIZE (go/net-mgmt_up-go/up-go-v1.3.0/v1.3.0.mod) = 234
+SHA256 (go/net-mgmt_up-go/up-go-v1.3.0/v1.3.0.zip) = 491e7552d3a62973dad5dec700a5cc3a8b5e4fc7186d75030c38d9a9069b2728
+SIZE (go/net-mgmt_up-go/up-go-v1.3.0/v1.3.0.zip) = 19747

--- a/net-mgmt/up-go/pkg-descr
+++ b/net-mgmt/up-go/pkg-descr
@@ -1,0 +1,2 @@
+Troubleshoot problems with your Internet connection
+based on different protocols and well-known public servers.


### PR DESCRIPTION
add port for up.

tested on 14.2 as well as tested the port builds under poudriere

sample run:

```
$ uname -a
FreeBSD quincy 14.2-RELEASE FreeBSD 14.2-RELEASE releng/14.2-n269506-c8918d6c7412 GENERIC amd64

$ up -h

        Troubleshoot problems with your Internet connection based on different
        protocols and public servers.

        OUTPUT
        Details about each request:
        {Protocol used} {Response time} {Remote server} {Extra info}

        EXIT STATUS
        This utility exits with one of the following values:
        0 At least one response was heard.
        2 The transmission was successful but no responses were received.
        1 Any other error occurred.

Usage of up:
  -c uint
        Number of iterations
  -d duration
        Delay between requests (default 500ms)
  -dr string
        DNS resolution server
  -g    Output in grepable format
  -h    Show app documentation
  -j    Output in JSON format
  -nc
        Disable color output
  -nstd
        Disable standard input target reading
  -p string
        Test only one protocol
  -s    Stop after the first successful request
  -t duration
        Time to wait for a response (default 5s)
  -tg string
        Protocol is required because the format is dependent: URL for HTTP, host:port for TCP, domain for DNS
  -vv
        Verbose output
```