### PR TITLE
sysutils/sysinfo: fix default config

### DIFF
--- a/sysutils/sysinfo/Makefile
+++ b/sysutils/sysinfo/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	sysinfo
 PORTVERSION=	1.0.4
+PORTREVISION=	1
 CATEGORIES=	sysutils
 MASTER_SITES=	https://codeberg.org/BSDforge/${PORTNAME}/archive/${DISTVERSION}${EXTRACT_SUFX}?dummy=/
 

--- a/sysutils/sysinfo/pkg-plist
+++ b/sysutils/sysinfo/pkg-plist
@@ -1,4 +1,4 @@
-%%ETCDIR%%.conf.sample
+@sample %%ETCDIR%%.conf.sample
 sbin/sysinfo
 share/man/man5/sysinfo.conf.5.gz
 share/man/man8/sysinfo.8.gz


### PR DESCRIPTION
Commit 80813f1400207f7e8c90b918ade272328eb4caeb broke the default installation:
  $ sysinfo -a
  sysinfo: ERROR: Configuration file was found

Since, there was no explanation in the commit message we assume that was an oversight. So here we go and restore the old behaviour.

Fixes: 80813f1400207f7e8c90b918ade272328eb4caeb

cc: @fernape