### PR TITLE
sysutils/podman: Use full path for alpine image

### DIFF
--- a/sysutils/podman/pkg-message
+++ b/sysutils/podman/pkg-message
@@ -19,7 +19,7 @@ It is possible to run many Linux container images using FreeBSD's Linux emulatio
 
 $ sudo sysrc linux_enable=YES
 $ sudo service linux start
-$ sudo podman run --rm --os=linux alpine cat /etc/os-release | head -1
+$ sudo podman run --rm --os=linux docker.io/library/alpine cat /etc/os-release | head -1
 NAME="Alpine Linux"
 EOM
 }


### PR DESCRIPTION
Use full path for alpine image so newcomers to podman on FreeBSD aren't stopped by this error message:

`Error: short-name "alpine" did not resolve to an alias and no unqualified-search registries are defined in "/usr/local/etc/containers/registries.conf"`
