### PR TITLE
rpi cm4: enable USB(keyboard etc.) on boot

### DIFF
--- a/sysutils/rpi-firmware/files/config_arm64.txt
+++ b/sysutils/rpi-firmware/files/config_arm64.txt
@@ -9,3 +9,9 @@ kernel=u-boot.bin
 [pi4]
 hdmi_safe=1
 armstub=armstub8-gic.bin
+
+[cm4]
+otg_mode=1
+
+[cm5]
+dtoverlay=dwc2,dr_mode=host


### PR DESCRIPTION
-- also patch in src required : https://github.com/freebsd/freebsd-src/pull/1711 

U-Boot 2025.04 (May 20 2025 - 05:56:19 +0200)

DRAM:  948 MiB (effective 7.9 GiB)
RPI Compute Module 4 (0xd03140)
Core:  211 devices, 16 uclasses, devicetree: board
MMC:   mmc@7e300000: 3, mmc@7e340000: 0
L.......

---BEFORE this patch:---
starting USB...
No USB controllers found.......

-- AFTER this patch:---
starting USB...
Bus usb@7e980000: USB DWC2
scanning bus usb@7e980000 for devices... 5 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
U-Boot> usb info 3
config for device 3
4: Human Interface,  USB Revision 1.10
 - Mitsumi Electric Apple Extended USB Keyboard 
.....