### PR TITLE
Update netbird.in

### DIFF
--- a/security/netbird/files/netbird.in
+++ b/security/netbird/files/netbird.in
@@ -4,15 +4,70 @@
 # REQUIRE: SERVERS
 # KEYWORD: shutdown
 #
+# Add the following lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# netbird_enable (bool):        Set it to YES to enable Netbird.
+#                                   Default is "NO".
+# netbird_config_file (str):    Set Netbird config file location.
+#                                   Default is "/var/db/netbird/config.json"
+# netbird_daemon_addr (str):    Set Daemon service address to serve CLI requests.
+#                                   Pattern to use [unix|tcp]://[path|host:port].
+#                                   Default is "unix:///var/run/netbird.sock".
+# netbird_log_file (str):       Set Netbird log path.
+#                                   If console is specified the log will be output to stdout.
+#                                   If syslog is specified the log will be sent to syslog daemon.
+#                                   Default is "/var/log/netbird/client.log".
+# netbird_log_level (str):      Set Netbird log level
+#                                   Default is "info".
+# netbird_tun_dev (str):        Set the name of the tun interface Netbird creates.
+#                                   Default is "wt0"
 
 . /etc/rc.subr
 
 name="netbird"
-netbird_env="IS_DAEMON=1"
-pidfile="/var/run/${name}.pid"
+rcvar=netbird_enable
+
+load_rc_config $name
+
+: ${netbird_enable:="NO"}
+: ${netbird_config_file:="/var/db/netbird/config.json"}
+: ${netbird_daemon_addr:="unix:///var/run/netbird.sock"}
+: ${netbird_log_file:="/var/log/netbird/client.log"}
+: ${netbird_log_level:="info"}
+: ${netbird_tun_dev:="wt0"}
+
+pidfile="/var/run/${name}_daemon.pid"
+pidfile_netbird="/var/run/${name}.pid"
+
 command="/usr/sbin/daemon"
-daemon_args="-P ${pidfile} -r -t \"${name}: daemon\""
-command_args="${daemon_args} /usr/local/bin/netbird service run --config /var/db/netbird/config.json --log-level info --daemon-addr unix:///var/run/netbird.sock --log-file /var/log/netbird/client.log"
+command_netbird="/usr/local/bin/${name}"
+daemon_args="-f -P ${pidfile} -p ${pidfile_netbird} -r -t \"${name}: daemon\""
+command_args="${daemon_args} ${command_netbird} service run --config ${netbird_config_file} --daemon-addr ${netbird_daemon_addr} --log-level ${netbird_log_level} --log-file ${netbird_log_file}"
+
+start_precmd="${name}_precmd"
+stop_postcmd="${name}_stop_postcmd"
+
+netbird_precmd() {
+
+    logger -s -t netbird "Starting ${name}."
+
+    # Check for orphaned netbird tunnel interface
+    # And if it exists, then destroy it
+    if /sbin/ifconfig ${netbird_tun_dev} >/dev/null 2>&1; then
+        if ! /sbin/ifconfig ${netbird_tun_dev} | fgrep -qw PID; then
+            logger -s -t netbird "Found orphaned tunnel interface ${netbird_tun_dev}, destroying"
+            /sbin/ifconfig ${netbird_tun_dev} destroy
+        fi
+    fi
+}
+
+netbird_stop_postcmd() {
+    if /sbin/ifconfig ${netbird_tun_dev} >/dev/null 2>&1; then
+        logger -s -t netbird "Destroying tunnel interface ${netbird_tun_dev}"
+        /sbin/ifconfig ${netbird_tun_dev} destroy || \
+            logger -s -t netbird "Failed to destroy interface ${netbird_tun_dev}"
+    fi
+}
 
 run_rc_command "$1"
-


### PR DESCRIPTION
added several rcvar with default values to allow control from rc.conf.d, and pre_cmd to check and destroy orphaned interfaces.

The variable "netbird_env" is removed, as "service netbird status" gives an error that it's not found.