### PR TITLE
Fix X11 ports to use GL_DEFAULT for mesa building

### DIFF
--- a/x11-servers/xorg-server/Makefile
+++ b/x11-servers/xorg-server/Makefile
@@ -38,10 +38,10 @@ PLIST_FILES=	bin/${BINARY_NAME} \
 
 DESCR=	${.CURDIR}/pkg-descr-${FLAVOR}
 
-BUILD_DEPENDS+=	${LOCALBASE}/libdata/pkgconfig/dri.pc:graphics/mesa-dri
+BUILD_DEPENDS+=	${LOCALBASE}/libdata/pkgconfig/dri.pc:graphics/${GL_DEFAULT}
 RUN_DEPENDS+=	xkeyboard-config>=2.5:x11/xkeyboard-config \
 		xkbcomp:x11/xkbcomp \
-		${LOCALBASE}/libdata/pkgconfig/dri.pc:graphics/mesa-dri
+		${LOCALBASE}/libdata/pkgconfig/dri.pc:graphics/${GL_DEFAULT}
 
 MESON_ARGS+=	-Dxwin=false \
 		-Dxquartz=false \

--- a/x11-servers/xwayland/Makefile
+++ b/x11-servers/xwayland/Makefile
@@ -12,7 +12,7 @@ LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	evdev-proto>0:devel/evdev-proto \
-		${LOCALBASE}/include/GL/internal/dri_interface.h:graphics/mesa-dri \
+		${LOCALBASE}/include/GL/internal/dri_interface.h:graphics/${GL_DEFAULT} \
 		wayland-protocols>=1.30:graphics/wayland-protocols
 LIB_DEPENDS=	libdrm.so:graphics/libdrm \
 		libepoxy.so:graphics/libepoxy \

--- a/x11/xorg/Makefile
+++ b/x11/xorg/Makefile
@@ -9,7 +9,7 @@ WWW=		https://www.x.org/
 
 USES=		metaport
 
-RUN_DEPENDS+=	${LOCALBASE}/libdata/pkgconfig/dri.pc:graphics/mesa-dri
+RUN_DEPENDS+=	${LOCALBASE}/libdata/pkgconfig/dri.pc:graphics/${GL_DEFAULT}
 
 # data
 RUN_DEPENDS+=	${LOCALBASE}/libdata/pkgconfig/xbitmaps.pc:x11/xbitmaps \


### PR DESCRIPTION
After adding graphics/mesa-devel to my `DEFAULT_VERSIONS` in my make.conf, I was continuously having x11-wm/plasma6-kwin failing to build using poudriere at the lib-depends phase with the following error:
```
pkg-static: mesa-devel-25.1.b.2196 conflicts with mesa-libs-24.1.7_1 (installs files into the same place).  Problematic file: /usr/local/include/EGL/eglext_angle.h
```
In addition, every time I try to rebuild plasma6-kwin, it would constantly force delete the existing built package for x11-servers/xwayland and rebuild it again. Lather-rinse-repeat.

The problem was that xwayland was still using mesa-dri as the build dep, not allowing the flexibility to use mesa-devel and going into a rebuild loop. This fix solves it.

After continuing to finish rebuilding my package cache, I was noticing similar "rebuild loop" patterns with xorg and xorg-server. So I fixed them the same way. It all builds and I'm now daily driving it.