### PR TITLE
net/mosquitto: don't set cafile in example config

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	mosquitto
 DISTVERSION=	2.0.21
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	net
 MASTER_SITES=	https://mosquitto.org/files/source/
 

--- a/net/mosquitto/files/patch-mosquitto.conf
+++ b/net/mosquitto/files/patch-mosquitto.conf
@@ -23,7 +23,7 @@
  # "openssl rehash <path to capath>" each time you add/remove a certificate.
  # capath is not supported for websockets.
 -#cafile
-+cafile /usr/local/share/certs/ca-root-nss.crt
++#cafile /usr/local/share/certs/ca-root-nss.crt
  #capath
  
  


### PR DESCRIPTION
Recently mosquitto started checking for invalid combinations of cafile/capath/certfile/keyfile: https://github.com/eclipse-mosquitto/mosquitto/commit/87488a27f0e74e65ff095644d292fa457b2c003d

We want to have the cafile as an example, so let's make it a comment.

Fixes: f629958a28c5 ("net/mosquitto: Update to 2.0.21")