### PR TITLE
Update URL to Jason Heiss' new location

### DIFF
--- a/mail/sendmail/files/tls-install.sh
+++ b/mail/sendmail/files/tls-install.sh
@@ -77,7 +77,7 @@ sed 's/^X//' << 'END-of-files/tls.m4'
 X# links:
 X# http://www.sendmail.org/~gshapiro/
 X# http://www.sendmail.org/~ca/email/starttls.html
-X# http://www.ofb.net/~jheiss/sendmail/tlsandrelay.shtml
+X# https://aput.net/~jheiss/sendmail/tlsandrelay.shtml
 X#
 X# You may need to add this to your sendmail.mc file:
 X


### PR DESCRIPTION
Tracking the archive.org path showing 302 back in 13 Jul 2010 points to new location.