### PR TITLE
devel/hpx: enable riscv64 build

### DIFF
--- a/devel/hpx/Makefile
+++ b/devel/hpx/Makefile
@@ -19,7 +19,6 @@ LICENSE_FILE=	${WRKSRC}/LICENSE_1_0.txt
 BROKEN_armv7=	compilation fails: no matching function for call to 'bit_cast', see https://github.com/STEllAR-GROUP/hpx/issues/6557
 BROKEN_i386=	compilation fails: detail/tagged_ptr_pair.hpp:117:27: error: no matching function for call to 'bit_cast', see https://github.com/STEllAR-GROUP/hpx/issues/6426
 BROKEN_powerpc=	compilation fails: detail/tagged_ptr_pair.hpp:117:27: error: no matching function for call to 'bit_cast', see https://github.com/STEllAR-GROUP/hpx/issues/6426
-BROKEN_riscv64=	hpx/hardware/timestamp.hpp:43:6: error: Unsupported platform
 
 BUILD_DEPENDS=	asio>0:net/asio
 LIB_DEPENDS=	libboost_filesystem.so:devel/boost-libs \


### PR DESCRIPTION
Tested on Milkv Megrez