### PR TITLE
shells/bash-completion: Work around riscv64 extraction bug

### DIFF
--- a/shells/bash-completion/Makefile
+++ b/shells/bash-completion/Makefile
@@ -59,4 +59,10 @@ do-test:
 	-cd ${WRKSRC}/test && bash ${test}
 .endfor
 
+# Extraction fails with poudriere on riscv64
+# see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289914
+.if ${ARCH} == riscv64
+EXTRACT_CMD=	${SETENV} LC_ALL=en_US.UTF-8 /usr/bin/bsdtar
+.endif
+
 .include <bsd.port.mk>


### PR DESCRIPTION
Extraction failed with poudriere on riscv64 with following error:

```
===>  Extracting for bash-completion-2.16.0,2
=> SHA256 Checksum OK for bash-completion-2.16.0.tar.xz.
tar: Pathname can't be converted from UTF-8 to current locale.
tar: Pathname can't be converted from UTF-8 to current locale.
tar: Pathname can't be converted from UTF-8 to current locale.
tar: Error exit delayed from previous errors.
===>  Failed to extract "/portdistfiles/bash-completion-2.16.0.tar.xz".
```

Enforcing use of bsdtar works around the issue.
See also bug https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=289914