### PR TITLE
[NEW_PORT] comms/uhubctl: utility to control usb hub port power.

### DIFF
--- a/comms/uhubctl/Makefile
+++ b/comms/uhubctl/Makefile
@@ -1,0 +1,22 @@
+PORTNAME=	uhubctl
+DISTVERSION=	2.6.0
+CATEGORIES=	comms devel sysutils
+
+MAINTAINER=	tomek@cedro.info
+COMMENT=	Utility to control USB power per-port on smart USB hubs
+WWW=		https://github.com/mvp/uhubctl
+
+LICENSE=	GPLv2
+LICENSE_FILE	=${WRKSRC}/LICENSE
+
+USES=		gmake
+USE_GITHUB=	yes
+GH_ACCOUNT=	mvp
+GH_TAGNAME=	v2.6.0
+
+ALL_TARGET=	uhubctl
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/uhubctl ${STAGEDIR}${PREFIX}/sbin
+
+.include <bsd.port.mk>

--- a/comms/uhubctl/distinfo
+++ b/comms/uhubctl/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1759444934
+SHA256 (mvp-uhubctl-2.6.0-v2.6.0_GH0.tar.gz) = 56ca15ddf96d39ab0bf8ee12d3daca13cea45af01bcd5a9732ffcc01664fdfa2
+SIZE (mvp-uhubctl-2.6.0-v2.6.0_GH0.tar.gz) = 29255

--- a/comms/uhubctl/pkg-descr
+++ b/comms/uhubctl/pkg-descr
@@ -1,0 +1,9 @@
+Uhubctl is utility to control USB power per-port on smart USB hubs.
+Smart hub is defined as one that implements per-port power switching.
+
+Note that quite a few modern motherboards have built-in root hubs
+that do support this feature - you may not even need to buy any external hub.
+
+This utility was tested to compile and work on Linux (Ubuntu/Debian/Raspbian,
+Redhat/EPEL/Fedora/CentOS, Arch Linux, Gentoo, openSUSE, Buildroot), FreeBSD,
+NetBSD, SunOS and MacOS.

--- a/comms/uhubctl/pkg-plist
+++ b/comms/uhubctl/pkg-plist
@@ -1,0 +1,1 @@
+sbin/uhubctl


### PR DESCRIPTION
Uhubctl is utility to control USB power per-port on smart USB hubs. Smart hub is defined as one that implements per-port power switching.

Note that quite a few modern motherboards have built-in root hubs that do support this feature - you may not even need to buy any external hub.

This utility was tested to compile and work on Linux (Ubuntu/Debian/Raspbian, Redhat/EPEL/Fedora/CentOS, Arch Linux, Gentoo, openSUSE, Buildroot), FreeBSD, NetBSD, SunOS and MacOS.

WWW: https://github.com/mvp/uhubctl