### PR TITLE
Fix Logrotate to work by default

### DIFF
--- a/sysutils/logrotate/files/logrotate.conf.sample
+++ b/sysutils/logrotate/files/logrotate.conf.sample
@@ -17,6 +17,7 @@ include __PREFIX__/etc/logrotate.d
 /var/log/lastlog {
     monthly
     rotate 1
+    missingok
 }
 
 # system-specific logs may be configured here


### PR DESCRIPTION
if the file `/var/log/lastlog` is missing, logrotate fails, even if other configs are available.

add `missingok` to this block so other logrorate blocks located in `/usr/local/etc/logrotate.d/` will function as expected when that one file is unavailable.