### PR TITLE
[sysutils/alloy] Update to v1.13.1

### DIFF
--- a/sysutils/alloy/Makefile
+++ b/sysutils/alloy/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	alloy
 DISTVERSIONPREFIX=	v
-DISTVERSION=	1.10.2
-PORTREVISION=	11
+DISTVERSION=	1.13.1
+PORTREVISION=	0
 CATEGORIES=	sysutils
 
 MAINTAINER=	zach.leslie@grafana.com
@@ -10,30 +10,62 @@ WWW=		https://github.com/grafana/alloy
 
 LICENSE=	MIT
 
-USES=		go:modules
+# no_targets: we supply do-build/do-install for the collector submodule.
+USES=		go:modules,no_targets
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	grafana
 
+# Fetch go.mod from GitHub rather than GOPROXY so the framework does not
+# also download a GOPROXY zip, which would conflict with the GitHub tarball
+# WRKSRC.  With GO_MOD_DIST=github, go.mk skips the GOPROXY zip and leaves
+# WRKSRC set correctly by USE_GITHUB.
+GO_MOD_DIST=	github
+
 USE_RC_SUBR=	${PORTNAME}
 
 GO_MODULE=	github.com/${GH_ACCOUNT}/${GH_PROJECT}
-GO_PKGNAME=	github.com/${GH_ACCOUNT}/${GH_PROJECT}
-GO_TARGET=	github.com/${GH_ACCOUNT}/${GH_PROJECT}
 GO_BUILDFLAGS=	-ldflags='-X github.com/grafana/alloy/internal/build.Version=${GH_TAGNAME}'
 
+# The main go.mod has "replace ./syntax => ./syntax".  go-post-fetch (800)
+# runs go mod download from DIST_SUBDIR and needs syntax/go.mod present.
+# post-fetch runs at priority 700, after do-fetch (500) downloads the tarball.
 post-fetch:
-	@${ECHO_MSG} "===> Fetching ${GO_MODNAME}/syntax dependency"
-	(cd ${DISTDIR}/${DIST_SUBDIR}; [ -e syntax/go.mod ] || (\
+	@(cd ${DISTDIR}/${DIST_SUBDIR}; [ -e syntax/go.mod ] || (\
 		${MKDIR} syntax; \
 		${TAR} -xzf ${DISTNAME}${EXTRACT_SUFX} ${PORTNAME}-${DISTVERSION}/syntax/go.mod; \
 		${CP} ${PORTNAME}-${DISTVERSION}/syntax/go.mod syntax/go.mod))
 
-post-extract:
-	${CP} -r ${WRKDIR}/${PORTNAME}-${DISTVERSION}/syntax ${GO_WRKSRC}
+# collector/ is a separate Go module with its own dependencies.  Download
+# them at fetch time; extract has no network access in poudriere.
+_USES_fetch+=	900:alloy-fetch-collector-deps
+alloy-fetch-collector-deps:
+	@${ECHO_MSG} "===> Fetching collector submodule dependencies"; \
+	td=$$(mktemp -d -t alloy_collector_deps); \
+	trap "rm -rf $$td" 0; \
+	${TAR} -xzf ${DISTDIR}/${DIST_SUBDIR}/${DISTNAME}${EXTRACT_SUFX} -C $$td; \
+	(cd $$td/${PORTNAME}-${DISTVERSION}/collector && \
+		${SETENVI} ${WRK_ENV} GOPATH="${GO_GOPATH}" GO111MODULE=on GOFLAGS=-modcacherw GOSUMDB=sum.golang.org \
+		GOPROXY=${GO_GOPROXY} ${GO_CMD} mod download -x all); \
+	rm -rf $$td
+
+# After go-post-extract (800) vendors the main module, vendor collector/
+# using the module cache populated above.
+_USES_extract+=	900:alloy-vendor-collector
+alloy-vendor-collector:
+	@${ECHO_MSG} "===> Vendoring collector submodule"; \
+	(cd ${WRKSRC}/collector && \
+		${SETENVI} ${WRK_ENV} ${MAKE_ENV} ${GO_ENV} GOPROXY=${GO_MODCACHE} \
+		${GO_CMD} mod vendor -e)
+
+# The alloy binary lives in collector/, a separate Go module.
+do-build:
+	(cd ${WRKSRC}/collector; \
+		${SETENVI} ${WRK_ENV} ${MAKE_ENV} ${GO_ENV} GOMAXPROCS=${MAKE_JOBS_NUMBER} GOPROXY=off \
+		${GO_CMD} build ${GO_BUILDFLAGS} -mod=vendor -o ${GO_WRKDIR_BIN}/alloy .)
 
 do-install:
-	${INSTALL_PROGRAM} ${WRKDIR}/bin/${PORTNAME} ${STAGEDIR}${PREFIX}/bin
+	${INSTALL_PROGRAM} ${GO_WRKDIR_BIN}/alloy ${STAGEDIR}${PREFIX}/bin/${PORTNAME}
 	${INSTALL_DATA} ${WRKSRC}/example-config.alloy ${STAGEDIR}${PREFIX}/etc/alloy.flow.sample
 	${MKDIR} ${STAGEDIR}/var/${PORTNAME}
 

--- a/sysutils/alloy/distinfo
+++ b/sysutils/alloy/distinfo
@@ -1,7 +1,5 @@
-TIMESTAMP = 1756329743
-SHA256 (go/sysutils_alloy/grafana-alloy-v1.10.2_GH0/v1.10.2.mod) = 00055a9dafa0182283fbb801d6bc092ffbec438405c190f3a57010f07783bcaa
-SIZE (go/sysutils_alloy/grafana-alloy-v1.10.2_GH0/v1.10.2.mod) = 67450
-SHA256 (go/sysutils_alloy/grafana-alloy-v1.10.2_GH0/v1.10.2.zip) = c1603f2447f19178e67e906c9dc012a47a77f328c6d3cf997ab1fbeea12ba258
-SIZE (go/sysutils_alloy/grafana-alloy-v1.10.2_GH0/v1.10.2.zip) = 14528199
-SHA256 (go/sysutils_alloy/grafana-alloy-v1.10.2_GH0/grafana-alloy-v1.10.2_GH0.tar.gz) = ed170622458600dd335dbdea12cf88a6bee33df1949a58b31a707b1a84f65b0f
-SIZE (go/sysutils_alloy/grafana-alloy-v1.10.2_GH0/grafana-alloy-v1.10.2_GH0.tar.gz) = 12779185
+TIMESTAMP = 1771875883
+SHA256 (go/sysutils_alloy/grafana-alloy-v1.13.1_GH0/go.mod) = 2664a5fe70d0ccd10783f47038738ced9007fc5f04f2f3252c44a47030218681
+SIZE (go/sysutils_alloy/grafana-alloy-v1.13.1_GH0/go.mod) = 66864
+SHA256 (go/sysutils_alloy/grafana-alloy-v1.13.1_GH0/grafana-alloy-v1.13.1_GH0.tar.gz) = 46bad79b5ba502d93c57b4dfe59aadc362cda173290760d8da33080552f53d9a
+SIZE (go/sysutils_alloy/grafana-alloy-v1.13.1_GH0/grafana-alloy-v1.13.1_GH0.tar.gz) = 18140497

--- a/sysutils/alloy/files/alloy.in
+++ b/sysutils/alloy/files/alloy.in
@@ -19,6 +19,9 @@
 #               Default is "/var/alloy".
 # alloy_args (string):          Set extra arguments to pass to alloy
 #               Default is "".
+# alloy_sig_stop (string):      Signal used to stop alloy. Default "TERM".
+# alloy_stop_timeout (int):     Seconds to wait for graceful stop before SIGKILL.
+#               Default is unset (rc.subr default wait). Set e.g. 30 for a timeout.
 
 . /etc/rc.subr
 
@@ -33,20 +36,45 @@ load_rc_config $name
 : ${alloy_args:=""}
 : ${alloy_storage_path:="/var/alloy"}
 : ${alloy_listen_address:=":9200"}
+: ${alloy_sig_stop:="TERM"}
+: ${alloy_stop_timeout:=}
 
 pidfile=/var/run/alloy.pid
 command="/usr/sbin/daemon"
 procname="%%PREFIX%%/bin/alloy"
 run="run /usr/local/etc/alloy.flow"
-command_args="-S -T ${name} -p ${pidfile} /usr/bin/env ${procname} ${run} \
+command_args="-f -S -T ${name} -p ${pidfile} /usr/bin/env ${procname} ${run} \
     --storage.path=${alloy_storage_path} --server.http.listen-addr=${alloy_listen_address} ${alloy_args}"
 
+# Alloy reloads config on SIGHUP (see /-/reload and internal/alloycli/cmd_run.go).
+sig_stop="${alloy_sig_stop}"
+sig_reload="HUP"
+extra_commands="reload"
+
 start_precmd=alloy_startprecmd
+stop_postcmd=alloy_stoppostcmd
+[ -n "${alloy_stop_timeout}" ] && stop_cmd="alloy_stop"
 
 alloy_startprecmd() {
   if [ ! -e ${pidfile} ]; then
     install -o ${alloy_user} -g ${alloy_group} /dev/null ${pidfile}
   fi
+}
+
+alloy_stoppostcmd() {
+  rm -f ${pidfile}
+}
+
+alloy_stop() {
+  rc_pid=$(check_pidfile "${pidfile}" "${procname}")
+  if [ -z "${rc_pid}" ]; then
+    return 0
+  fi
+  echo "Stopping ${name}."
+  kill -${sig_stop} "${rc_pid}"
+  wait_for_pids "${pidfile}" ${alloy_stop_timeout}
+  kill -KILL "${rc_pid}" 2>/dev/null && echo "Killed."
+  rm -f "${pidfile}"
 }
 
 load_rc_config $name


### PR DESCRIPTION
### Why this port requires custom fetch/extract hooks

Alloy's upstream source has two constraints that prevent a fully standard go:modules build:

1. The main go.mod contains replace github.com/grafana/alloy/syntax => ./syntax. The framework's go mod download step runs from DIST_SUBDIR where only go.mod exists, so ./syntax/go.mod must be staged there first. post-fetch (priority 700) extracts it from the tarball before go-post-fetch (priority 800) runs.
2. The alloy binary lives in collector/, a separate Go module with its own go.mod and dependency tree. go mod vendor for the main module does not vendor collector/'s dependencies. Since extract-time has no network access in poudriere, collector/'s dependencies must be downloaded at fetch time (_USES_fetch+=900) and vendored at extract time (_USES_extract+=900).

Fetch approach

GO_MOD_DIST=github is used so the framework fetches go.mod from raw GitHub rather than GOPROXY. This avoids the framework also downloading a GOPROXY zip, which would override WRKSRC to the module cache path and conflict with the GitHub tarball extraction. With this setting, WRKSRC is set correctly by USE_GITHUB to alloy-1.13.1/, which already contains the syntax/, collector/, and extension/ subdirectories needed by go mod vendor.

Changes from the previous submission

- Removed pre/post-install service management scripts per reviewer feedback; administrators manage service lifecycle during upgrades.
- Simplified hook structure: removed the intermediate extract hook that was copying local subdirectories to a GOPROXY-path WRKSRC (no longer needed with the corrected WRKSRC).

rc script improvements

- sig_reload=HUP - alloy reloads its configuration on SIGHUP (via /-/reload); service alloy reload now works.
- alloy_sig_stop - configurable stop signal (default TERM).
- alloy_stop_timeout - optional graceful shutdown timeout before SIGKILL.
- `daemon -f` - fix stale pidfile on restart

Related:
[292472](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=292472)
[294288](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=294288)
