### PR TITLE
lang/ferrumc: new port, Ferrum-language compiler 0.3.0

### DIFF
--- a/lang/ferrumc/Makefile
+++ b/lang/ferrumc/Makefile
@@ -6,7 +6,7 @@ MAINTAINER=	ports@FreeBSD.org
 COMMENT=	Ferrum-language compiler with compile-time memory safety
 WWW=		https://ferrum-language.github.io/Ferrum/
 
-LICENSE=	MIT
+LICENSE=	GPLv3
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 USES=		tar:tgz

--- a/lang/ferrumc/Makefile
+++ b/lang/ferrumc/Makefile
@@ -6,7 +6,7 @@ MAINTAINER=	ports@FreeBSD.org
 COMMENT=	Ferrum-language compiler with compile-time memory safety
 WWW=		https://ferrum-language.github.io/Ferrum/
 
-LICENSE=	GPLv3
+LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 USES=		tar:tgz
@@ -16,7 +16,11 @@ DISTFILES=	ferrumc-v${DISTVERSION}-freebsd-x86_64.tar.gz
 MASTER_SITES=	https://github.com/Ferrum-Language/Ferrum/releases/download/v${DISTVERSION}/
 DIST_SUBDIR=	ferrumc
 
+ONLY_FOR_ARCHS=		amd64
+ONLY_FOR_ARCHS_REASON=	prebuilt binary only available for amd64
+
 NO_BUILD=	yes
+PLIST_FILES=	bin/ferrumc
 
 do-install:
 	${INSTALL_PROGRAM} ${WRKDIR}/ferrumc ${STAGEDIR}${PREFIX}/bin/ferrumc

--- a/lang/ferrumc/Makefile
+++ b/lang/ferrumc/Makefile
@@ -1,0 +1,24 @@
+PORTNAME=	ferrumc
+DISTVERSION=	0.3.0
+CATEGORIES=	lang
+
+MAINTAINER=	ports@FreeBSD.org
+COMMENT=	Ferrum-language compiler with compile-time memory safety
+WWW=		https://ferrum-language.github.io/Ferrum/
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+USES=		tar:tgz
+
+DISTFILES=	ferrumc-v${DISTVERSION}-freebsd-x86_64.tar.gz
+
+MASTER_SITES=	https://github.com/Ferrum-Language/Ferrum/releases/download/v${DISTVERSION}/
+DIST_SUBDIR=	ferrumc
+
+NO_BUILD=	yes
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKDIR}/ferrumc ${STAGEDIR}${PREFIX}/bin/ferrumc
+
+.include <bsd.port.mk>

--- a/lang/ferrumc/distinfo
+++ b/lang/ferrumc/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1742687703
+SHA256 (ferrumc/ferrumc-v0.3.0-freebsd-x86_64.tar.gz) = eee60d697c6ffc610a629dd75e1710225432cc4cc205dc3e8d57a56a359b6463
+SIZE (ferrumc/ferrumc-v0.3.0-freebsd-x86_64.tar.gz) = 1842002

--- a/lang/ferrumc/pkg-descr
+++ b/lang/ferrumc/pkg-descr
@@ -1,5 +1,3 @@
 Ferrum-language is a systems programming language with C syntax and
 compile-time memory safety via a borrow checker and ownership model.
 Compiled to native code through LLVM 18.
-
-WWW: https://ferrum-language.github.io/Ferrum/

--- a/lang/ferrumc/pkg-descr
+++ b/lang/ferrumc/pkg-descr
@@ -1,0 +1,5 @@
+Ferrum-language is a systems programming language with C syntax and
+compile-time memory safety via a borrow checker and ownership model.
+Compiled to native code through LLVM 18.
+
+WWW: https://ferrum-language.github.io/Ferrum/


### PR DESCRIPTION
**New port submission: lang/ferrumc**

Ferrum-language is a systems programming language with C syntax and compile-time memory safety via a borrow checker and ownership model, compiled to native code through LLVM 18.

- License: MIT
- Homepage: https://ferrum-language.github.io/Ferrum/
- Upstream: https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
- SHA256: eee60d697c6ffc610a629dd75e1710225432cc4cc205dc3e8d57a56a359b6463

Port installs a prebuilt FreeBSD x86_64 binary to `${PREFIX}/bin/ferrumc`.