### PR TITLE
science/py-scipy: Keep build directory to simplify debugging

### DIFF
--- a/science/py-scipy/Makefile
+++ b/science/py-scipy/Makefile
@@ -41,7 +41,7 @@ TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pytest-cov>0:devel/py-pytest-cov@${PY_FLAVO
 USES=		compiler:c++17-lang cpe fortran pkgconfig python:3.11+ shebangfix
 USE_PYTHON=	autoplist concurrent cython pep517 pytest
 
-PEP517_BUILD_CONFIG_SETTING=	-Csetup-args=-Duse-system-libraries=all
+PEP517_BUILD_CONFIG_SETTING=	-Csetup-args=-Duse-system-libraries=all -Cbuild-dir=_build
 
 TEST_WRKSRC=	${WRKDIR}
 TEST_ARGS=	--pyargs scipy


### PR DESCRIPTION
This makes meson to keep the build directory and allows to check what flags were calculated during configure phase in case of any problems.