### PR TITLE
net/aquantia-atlantic-kmod: fix RSS stack overflow (panic / no link)

### DIFF
--- a/net/aquantia-atlantic-kmod/Makefile
+++ b/net/aquantia-atlantic-kmod/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	aquantia-atlantic-kmod
 PORTVERSION=	0.0.5
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	net
 
 MAINTAINER=	ports@FreeBSD.org

--- a/net/aquantia-atlantic-kmod/files/patch-aq__hw.c
+++ b/net/aquantia-atlantic-kmod/files/patch-aq__hw.c
@@ -1,5 +1,13 @@
-Upstream PR:
-https://github.com/Aquantia/aqtion-freebsd/pull/27
+net/aquantia-atlantic-kmod fixes for aq_hw.c:
+
+1) Drop <unistd.h>, a userland header that breaks the kernel build.
+   Aquantia PR: https://github.com/Aquantia/aqtion-freebsd/pull/27
+
+2) aq_hw_rss_set()'s bitary[] is one u16 too short, so the indirection-table
+   pack loop's last 32-bit write (i==63) lands one element past the array --
+   an out-of-bounds stack write. Depending on stack layout it either trips
+   -fstack-protector (kernel panic on ifconfig up) or returns and leaves the
+   driver unable to bring up link. Sizing it [1 + (...*3/16)] fixes both.
 
 --- aq_hw.c.orig
 +++ aq_hw.c
@@ -11,3 +19,12 @@ https://github.com/Aquantia/aqtion-freebsd/pull/27
  #include <sys/endian.h>
  #include <sys/param.h>
  #include <sys/systm.h>
+@@ -854,7 +853,7 @@
+ 
+ int aq_hw_rss_set(struct aq_hw_s *self, u8 rss_table[HW_ATL_RSS_INDIRECTION_TABLE_MAX])
+ {
+-	u16 bitary[(HW_ATL_RSS_INDIRECTION_TABLE_MAX *
++	u16 bitary[1 + (HW_ATL_RSS_INDIRECTION_TABLE_MAX *
+ 					3 / 16U)];
+ 	int err = 0;
+ 	u32 i = 0U;


### PR DESCRIPTION
aq_hw_rss_set()'s bitary[] is one u16 too short, so the indirection-table pack loop's last 32-bit write (i==63) lands one element past the array — an out-of-bounds stack write. Depending on stack layout it either trips -fstack-protector (kernel panic on ifconfig up) or returns and leaves the driver unable to bring up link. Sizing it [1 + (...*3/16)] fixes both.

Tested: AQC107 fw 3.1.88 on 15.0-RELEASE — 1000baseT-FDX