### PR TITLE
net/aquantia-atlantic-kmod: fix RSS stack overflow (panic / no link)

### DIFF
--- a/net/aquantia-atlantic-kmod/Makefile
+++ b/net/aquantia-atlantic-kmod/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	aquantia-atlantic-kmod
 PORTVERSION=	0.0.5
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	net
 
 MAINTAINER=	ports@FreeBSD.org

--- a/net/aquantia-atlantic-kmod/files/patch-aq__hw.c
+++ b/net/aquantia-atlantic-kmod/files/patch-aq__hw.c
@@ -1,5 +1,12 @@
-Upstream PR:
-https://github.com/Aquantia/aqtion-freebsd/pull/27
+net/aquantia-atlantic-kmod fixes for aq_hw.c:
+
+1) Drop <unistd.h>, a userland header that breaks the kernel build.
+   Upstream PR: https://github.com/Aquantia/aqtion-freebsd/pull/27
+
+2) aq_hw_rss_set()'s bitary[] is one u16 too short; the indirection-table
+   pack loop writes one element past it, smashing the stack canary (panic on
+   "ifconfig up") and corrupting the link-speed request (interface attaches
+   but stays "no carrier").  Size it [1 + (...*3/16)].
 
 --- aq_hw.c.orig
 +++ aq_hw.c
@@ -11,3 +18,18 @@ https://github.com/Aquantia/aqtion-freebsd/pull/27
  #include <sys/endian.h>
  #include <sys/param.h>
  #include <sys/systm.h>
+@@ -854,7 +853,13 @@
+ 
+ int aq_hw_rss_set(struct aq_hw_s *self, u8 rss_table[HW_ATL_RSS_INDIRECTION_TABLE_MAX])
+ {
+-	u16 bitary[(HW_ATL_RSS_INDIRECTION_TABLE_MAX *
++	/*
++	 * aq_hw_rss_set()'s bitary[] is one u16 too short; the indirection-table
++	 * pack loop writes one element past it, smashing the stack canary (panic
++	 * on "ifconfig up") and corrupting the link-speed request (interface
++	 * attaches but stays "no carrier").  Size it [1 + (...*3/16)].
++	 */
++	u16 bitary[1 + (HW_ATL_RSS_INDIRECTION_TABLE_MAX *
+ 					3 / 16U)];
+ 	int err = 0;
+ 	u32 i = 0U;


### PR DESCRIPTION
aq_hw_rss_set()'s bitary[] is one u16 too short, so the indirection-table pack loop's last 32-bit write (i==63) lands one element past the array — an out-of-bounds stack write. Depending on stack layout it either trips -fstack-protector (kernel panic on ifconfig up) or returns and leaves the driver unable to bring up link. Sizing it [1 + (...*3/16)] fixes both.

Verified on an AQC107 (firmware 3.1.88) under FreeBSD 15.0-RELEASE:
link negotiates 1000baseT full-duplex and passes traffic.

PORTREVISION bumped.

Signed-off-by: Nick Price <nick@spun.io>