### PR TITLE
net/aquantia-atlantic-kmod: fix OOB write in RSS table packing (no link / panic)

### DIFF
--- a/net/aquantia-atlantic-kmod/Makefile
+++ b/net/aquantia-atlantic-kmod/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	aquantia-atlantic-kmod
 PORTVERSION=	0.0.5
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	net
 
 MAINTAINER=	ports@FreeBSD.org

--- a/net/aquantia-atlantic-kmod/files/patch-aq__hw.c
+++ b/net/aquantia-atlantic-kmod/files/patch-aq__hw.c
@@ -1,5 +1,14 @@
-Upstream PR:
-https://github.com/Aquantia/aqtion-freebsd/pull/27
+net/aquantia-atlantic-kmod fixes for aq_hw.c:
+
+1) Drop <unistd.h>, a userland header that breaks the kernel build.
+   Aquantia PR: https://github.com/Aquantia/aqtion-freebsd/pull/27
+
+2) Fix an out-of-bounds stack write in aq_hw_rss_set().  RSS table entries
+   are 3 bits (8 queues max), but with more than 8 RX rings rss_table[]
+   holds larger values; the 32-bit write then spills one u16 past bitary[]
+   and corrupts the stack, so the NIC never links or the kernel panics.
+   Mask each value to 3 bits and pack 16 bits at a time to keep the write
+   in bounds.
 
 --- aq_hw.c.orig
 +++ aq_hw.c
@@ -11,3 +20,20 @@ https://github.com/Aquantia/aqtion-freebsd/pull/27
  #include <sys/endian.h>
  #include <sys/param.h>
  #include <sys/systm.h>
+@@ -862,8 +861,14 @@
+ 	memset(bitary, 0, sizeof(bitary));
+ 
+ 	for (i = HW_ATL_RSS_INDIRECTION_TABLE_MAX; i--;) {
+-		(*(u32 *)(bitary + ((i * 3U) / 16U))) |=
+-			((rss_table[i]) << ((i * 3U) & 0xFU));
++		u32 bit_pos = i * 3U;
++		u32 word = bit_pos / 16U;
++		u32 shift = bit_pos % 16U;
++		u32 val = (u32)(rss_table[i] & 0x7U) << shift;
++
++		bitary[word] |= (u16)val;
++		if ((val >> 16) && word + 1U < ARRAY_SIZE(bitary))
++			bitary[word + 1U] |= (u16)(val >> 16);
+ 	}
+ 
+ 	for (i = ARRAY_SIZE(bitary); i--;) {


### PR DESCRIPTION
Fix an out-of-bounds stack write in aq_hw_rss_set(). RSS table entries are 3 bits (8 queues max), but with more than 8 RX rings rss_table[] holds larger values; the 32-bit write then spills one u16 past bitary[] and corrupts the stack, so the NIC never links or the kernel panics.  Mask each value to 3 bits and pack 16 bits at a time to keep the write in bounds.

Confirmed on AQC107 (firmware 3.1.88) under FreeBSD 15.0-RELEASE: with the OOB write the interface attached but stayed "no carrier"; removed, link negotiates 1000baseT full-duplex and passes traffic.

PORTREVISION bumped.