### PR TITLE
mail/rspamd: update to 4.1.0

### DIFF
--- a/mail/rspamd/Makefile
+++ b/mail/rspamd/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	rspamd
-PORTVERSION=	4.0.0
+PORTVERSION=	4.0.1
 CATEGORIES=	mail
 
 MAINTAINER=	vsevolod@FreeBSD.org

--- a/mail/rspamd/Makefile
+++ b/mail/rspamd/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	rspamd
-PORTVERSION=	4.0.1
+PORTVERSION=	4.1.0
 CATEGORIES=	mail
 
 MAINTAINER=	vsevolod@FreeBSD.org

--- a/mail/rspamd/distinfo
+++ b/mail/rspamd/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1774928969
-SHA256 (rspamd-rspamd-4.0.0_GH0.tar.gz) = badd46de83a3dc831263bead1ffa7f5c9a1cea63e01e04493e89cd831732b7ff
-SIZE (rspamd-rspamd-4.0.0_GH0.tar.gz) = 6985425
+TIMESTAMP = 1780053265
+SHA256 (rspamd-rspamd-4.0.1_GH0.tar.gz) = 68b1c662c09817f962faebcd74f20afc0b64f6d7513c3782cd2bc2b2323a5cba
+SIZE (rspamd-rspamd-4.0.1_GH0.tar.gz) = 6998348

--- a/mail/rspamd/distinfo
+++ b/mail/rspamd/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1780053265
-SHA256 (rspamd-rspamd-4.0.1_GH0.tar.gz) = 68b1c662c09817f962faebcd74f20afc0b64f6d7513c3782cd2bc2b2323a5cba
-SIZE (rspamd-rspamd-4.0.1_GH0.tar.gz) = 6998348
+TIMESTAMP = 1780674799
+SHA256 (rspamd-rspamd-4.1.0_GH0.tar.gz) = 1e92b976aff69fe0b74c02819a2a26b5821e55f185b9acdb5ddc1c08bcbfde19
+SIZE (rspamd-rspamd-4.1.0_GH0.tar.gz) = 7161409


### PR DESCRIPTION
 Update mail/rspamd to 4.1.0.

 Changelog:
 https://github.com/rspamd/rspamd/releases/tag/4.1.0

 Build tested on FreeBSD 15.0-RELEASE amd64
 with HYPERSCAN and LUAJIT options enabled.

