### PR TITLE
net/turnserver: Run turnserver as non-root by default

### DIFF
--- a/GIDs
+++ b/GIDs
@@ -332,7 +332,7 @@ goimapnotify:*:387:
 autopulse:*:388:
 ldap:*:389:
 bunkerweb:*:390:
-# free: 391
+_turnserver:*:391:
 # free: 392
 # free: 393
 # free: 394

--- a/UIDs
+++ b/UIDs
@@ -337,7 +337,7 @@ goimapnotify:*:387:387::0:0:Goimapnotify Daemon:/nonexistent:/usr/sbin/nologin
 autopulse:*:388:388::0:0:Autopulse Daemon:/nonexistent:/usr/sbin/nologin
 ldap:*:389:389::0:0:OpenLDAP Server:/nonexistent:/usr/sbin/nologin
 bunkerweb:*:390:390::0:0:Bunkerweb Service:/nonexistent:/usr/sbin/nologin
-# free: 391
+_turnserver:*:391:391::0:0:Coturn Turnserver Daemon:/nonexistent:/usr/sbin/nologin
 # free: 392
 # free: 393
 # free: 394

--- a/net/turnserver/Makefile
+++ b/net/turnserver/Makefile
@@ -29,7 +29,12 @@ CONFIGURE_ENV+=	TURN_NO_MONGO=1
 
 TEST_TARGET=	test
 
+USERS=	_turnserver
+GROUPS=	_turnserver
+
 SUB_FILES=	pkg-message
+SUB_LIST=	USER=${USERS} \
+		GROUP=${GROUPS}
 
 MANPAGES=	turnserver.1 turnadmin.1 turnutils.1 turnutils_peer.1 \
 		turnutils_stunclient.1 turnutils_uclient.1 coturn.1 \

--- a/net/turnserver/files/turnserver.in
+++ b/net/turnserver/files/turnserver.in
@@ -11,6 +11,8 @@
 #				Set it to YES to enable turnserver.
 # turnserver_config (path):	Set to %%PREFIX%%/etc/turnserver.conf
 #				by default.
+# turnserver_user (str):	Set to %%USER%% by default.
+# turnserver_group (str):	Set to %%GROUP%% by default.
 
 . /etc/rc.subr
 
@@ -19,8 +21,10 @@ rcvar=turnserver_enable
 
 load_rc_config $name
 
-: ${turnserver_enable:=no}
-: ${turnserver_config=%%PREFIX%%/etc/turnserver.conf}
+: ${turnserver_enable:="NO"}
+: ${turnserver_config="%%PREFIX%%/etc/turnserver.conf"}
+: ${turnserver_user:="%%USER%%"}
+: ${turnserver_group:="%%GROUP%%"}
 
 command="%%PREFIX%%/bin/${name}"
 command_args="--daemon -c ${turnserver_config}"


### PR DESCRIPTION
Prior to this commit, turnserver is started as root by default. While privileges can be dropped via the `proc-user` and ``proc-group` configuration options, there was no registered user/group for turnserver.