### PR TITLE
graphics/openexr*: security update to 3.4.13

### DIFF
--- a/graphics/openexr-website-docs/Makefile
+++ b/graphics/openexr-website-docs/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	openexr-website-docs
-DISTVERSION=	3.4.12
+DISTVERSION=	3.4.13
 PORTREVISION=	0
 MASTER_SITES=	https://github.com/AcademySoftwareFoundation/openexr/releases/download/v${DISTVERSION}/:DEFAULT \
 		https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main/:website \

--- a/graphics/openexr-website-docs/distinfo
+++ b/graphics/openexr-website-docs/distinfo
@@ -1,6 +1,5 @@
-TIMESTAMP = 1779953033
-SHA256 (openexr/openexr-3.4.12.tar.gz) = 2d45db1d4bb78a5b263cd21cefa93119e1fcd37a13fa446c74663b6b8ec02d00
-SIZE (openexr/openexr-3.4.12.tar.gz) = 25762087
+SHA256 (openexr/openexr-3.4.13.tar.gz) = fe99c9cf06e41803db75ae4f5c9bb9955b7033ff47f05b02bc60bc5dba391996
+SIZE (openexr/openexr-3.4.13.tar.gz) = 25783727
 SHA256 (openexr/TestImages/README.rst) = 3cbb0a9ab20868940de1b9bf582bdc5ff4244cc585c682d6e40b9befb8fd593c
 SIZE (openexr/TestImages/README.rst) = 2588
 SHA256 (openexr/TestImages/AllHalfValues.exr) = eede573a0b59b79f21de15ee9d3b7649d58d8f2a8e7787ea34f192db3b3c84a4

--- a/graphics/openexr/Makefile
+++ b/graphics/openexr/Makefile
@@ -1,5 +1,5 @@
 PORTNAME?=	openexr
-DISTVERSION?=	3.4.12 # ALSO update openexr-website-docs! -- verify sigstore: make makesum verify-sigstore
+DISTVERSION?=	3.4.13 # ALSO update openexr-website-docs! -- verify sigstore: make makesum verify-sigstore
 PORTREVISION?=	0
 CATEGORIES=	graphics devel
 .if !defined(MASTERDIR)

--- a/graphics/openexr/distinfo
+++ b/graphics/openexr/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1779953240
-SHA256 (openexr/openexr-3.4.12.tar.gz) = 2d45db1d4bb78a5b263cd21cefa93119e1fcd37a13fa446c74663b6b8ec02d00
-SIZE (openexr/openexr-3.4.12.tar.gz) = 25762087
+TIMESTAMP = 1781941135
+SHA256 (openexr/openexr-3.4.13.tar.gz) = fe99c9cf06e41803db75ae4f5c9bb9955b7033ff47f05b02bc60bc5dba391996
+SIZE (openexr/openexr-3.4.13.tar.gz) = 25783727
 SHA256 (openexr/Beachball/multipart.0001.exr) = 0cd032069fbaa14a2766861fef9893ea66a6494ff64650725d3b26a500df774b
 SIZE (openexr/Beachball/multipart.0001.exr) = 2894260
 SHA256 (openexr/Beachball/singlepart.0001.exr) = 29719942ed3c095a8f8f111fc139fc4c28f446007f5bfce00177cae585b1a87a


### PR DESCRIPTION
Changelog:	https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.13
MFH:		2026Q2
PR:		296159

Security:	CVE-2026-55373
OpenEXRUtil SampleCountChannel endEdit() can loop forever on UINT_MAX sample counts

Security:	CVE-2026-55371
OpenEXRCore exr_attr_set_bytes() accepts NULL type_hint with positive hint_length

Security:	CVE-2026-55059
OpenEXRUtil SampleCountChannel row setter heap out-of-bounds

Security:	CVE-2026-54920
Integer Overflow and Use of Uninitialized Pointer leading to Invalid Delete in OpenEXRUtil Image Resize

Security:	CVE-2026-53532
Unhandled assert abort in HTJ2K decoder via crafted QCD marker (DoS)