### PR TITLE
seatd: add build-time custom socket path support

### DIFF
--- a/sysutils/seatd/Makefile
+++ b/sysutils/seatd/Makefile
@@ -16,6 +16,12 @@ USE_RC_SUBR=	${PORTNAME}
 CPE_VENDOR=	${PORTNAME}_project
 MESON_DISABLED=	libseat-logind
 SUB_FILES=	pkg-message
+
+# Socket path is compiled into seatd/libseat (SEATD_DEFAULTPATH).  Expose it
+# as a build-time knob; override with `make SEATD_SOCKET=...` or make.conf.
+SEATD_SOCKET?=
+MESON_ARGS+=	-Ddefaultpath=${SEATD_SOCKET}
+SUB_LIST+=	SEATD_SOCKET=${SEATD_SOCKET}
 PLIST_FILES=	bin/${PORTNAME} \
 		"@(,video,4750) bin/${PORTNAME}-launch" \
 		include/libseat.h \

--- a/sysutils/seatd/files/seatd.in
+++ b/sysutils/seatd/files/seatd.in
@@ -21,9 +21,22 @@ load_rc_config "$name"
 : ${seatd_enable="NO"}
 : ${seatd_args="-g video"}
 
+# Compiled-in socket path (meson -Ddefaultpath / SEATD_SOCKET at build time).
+seatd_socket="%%SEATD_SOCKET%%"
+
 command="/usr/sbin/daemon"
 procname="%%PREFIX%%/bin/${name}"
 pidfile="/var/run/${name}.pid"
 command_args="-s err -T ${name} -p ${pidfile} ${procname} ${seatd_args}"
+
+start_precmd="seatd_precmd"
+
+seatd_precmd()
+{
+	# seatd binds its socket at ${seatd_socket}; create the parent
+	# directory first since it may be nested and /var/run is volatile.
+	_dir="${seatd_socket%/*}"
+	[ "${_dir}" = "${seatd_socket}" ] || /bin/mkdir -p "${_dir}"
+}
 
 run_rc_command "$1"


### PR DESCRIPTION
This can be useful when one wants the socket to sit in a dedicated directory that can be exposed to jails as a nullfs mount.

@jbeich 