### PR TITLE
VuXML python re fix, VuXML entry for openvpn < 2.7.5 CVEs, py-breathe build fix (to fix unsupported graphics extension .svg)

### DIFF
--- a/devel/py-breathe/Makefile
+++ b/devel/py-breathe/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	breathe
 PORTVERSION=	4.36.0
+PORTREVISION=	1
 CATEGORIES=	devel python
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
@@ -19,7 +20,7 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}furo>=0:textproc/py-furo@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}sphinxcontrib-spelling>=0:textproc/py-sphinxcontrib-spelling@${PY_FLAVOR} \
 		doxygen:devel/doxygen
 
-USES=		gmake python
+USES=		gmake magick python
 USE_GITHUB=	yes
 GH_TUPLE=	michaeljones:breathe:v${PORTVERSION}
 USE_PYTHON=	autoplist pep517 pytest

--- a/devel/py-breathe/files/patch-documentation_source_conf.py
+++ b/devel/py-breathe/files/patch-documentation_source_conf.py
@@ -1,6 +1,15 @@
+diff -u documentation/source/conf.py.orig b/documentation/source/conf.py
 --- documentation/source/conf.py.orig	2026-04-26 08:35:23 UTC
 +++ documentation/source/conf.py
-@@ -37,12 +37,12 @@ else:
+@@ -22,6 +22,7 @@
+ extensions = [
+     "breathe",
+     "sphinx.ext.graphviz",
++    "sphinx.ext.imgconverter",
+     "sphinx_copybutton",
+     "sphinxcontrib.spelling",
+ ]
+@@ -37,12 +38,12 @@
      version = release = "compare"
  else:
      # Get a description of the current position.

--- a/security/vuxml/files/extra-validation.py
+++ b/security/vuxml/files/extra-validation.py
@@ -10,7 +10,7 @@ if len(sys.argv) != 2:
     sys.exit(1)
 
 re_date = re.compile(r'^(19|20)[0-9]{2}-[0-9]{2}-[0-9]{2}$')
-re_invalid_package_name = re.compile('[@!#$%^&*()<>?/\|}{~:]')
+re_invalid_package_name = re.compile(R'[@!#$%^&*()<>?/\|}{~:]')
 
 # warn if description has more than X characters
 DESCRIPTION_LENGTH = 5000

--- a/security/vuxml/vuln/2026.xml
+++ b/security/vuxml/vuln/2026.xml
@@ -793,6 +793,44 @@
     </dates>
   </vuln>
 
+  <vuln vid="ffa897a0-756f-11f1-b291-a74de6bb0320">
+    <topic>openvpn -- multiple vulnerabilities</topic>
+    <affects>
+      <package><name>openvpn</name> <range><lt>2.7.5</lt></range></package>
+      <package><name>openvpn-devel</name> <range><lt>g20260701,2</lt></range></package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The OpenVPN community project team reports:</p>
+	<blockquote cite="https://community.openvpn.net/Downloads#openvpn-275-released-1-july-2026">
+	  <p>[...] OpenVPN 2.7.5 [...] is a bugfix release fixing several security issues:</p>
+	  <ul>
+	    <li>Fix use-after-free bug in ack_write_buf(), triggerable by a well-timed sequence of control channel + authentication packets (CVE-2026-12996)</li>
+	    <li>Fix use-after-free bug in tls_wrap_reneg(), triggerable by suitable sequence of dynamic tls-crypt control-channel packets (CVE-2026-13117)</li>
+	    <li>Fix server crash on reception of suitably malformed auth-token, if --auth-gen-token external-auth is active (CVE-2026-13122)</li>
+	    <li>Fix memory-leak in tls-crypt-v2 client key handling that could lead to out-of-memory situations and subsequent server crashes (CVE-2026-12932)</li>
+	    <li>Fix possible 1-byte buffer overrun on NTLMv2 proxy responses. (CVE-2026-11771)</li>
+	    <li>Fix another memory leak on reception of suitable tls-crypt-v2 packets that could lead to an out of memory situation and server crash (CVE-2026-13698)</li>
+	  </ul>
+	</blockquote>
+      </body>
+    </description>
+    <references>
+      <url>https://github.com/OpenVPN/openvpn/blob/v2.7.5/Changes.rst#overview-of-changes-in-275</url>
+      <cvename>CVE-2026-11771</cvename>
+      <cvename>CVE-2026-12932</cvename>
+      <cvename>CVE-2026-12996</cvename>
+      <cvename>CVE-2026-13117</cvename>
+      <cvename>CVE-2026-13122</cvename>
+      <cvename>CVE-2026-13698</cvename>
+      <url>https://community.openvpn.net/Downloads#openvpn-275-released-1-july-2026</url>
+    </references>
+    <dates>
+      <discovery>2026-07-01</discovery>
+      <entry>2026-07-01</entry>
+    </dates>
+  </vuln>
+
   <vuln vid="78910e7e-74e3-11f1-958d-bc241121aa0a">
     <topic>FreeBSD -- Multiple vulnerabilities in iconv(3)</topic>
     <affects>


### PR DESCRIPTION
This contains a series of VuXML patches around https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=296429 and fixes py-breathe build for Bugzilla PR 296471.