### PR TITLE
mail/bogofilter*: Prepare LMDB 1.0 transition

### DIFF
--- a/UPDATING
+++ b/UPDATING
@@ -5,6 +5,27 @@ they are unavoidable.
 You should get into the habit of checking this file for changes each time
 you update your ports collection, before attempting any port upgrades.
 
+20260707:
+  AFFECTS: users of mail/bogofilter
+  AUTHOR: mandree@FreeBSD.org
+
+  Due to the LMDB 1.0 incompatibility (see 20260702 entry for
+  databases/lmdb), mail/bogofilter currently depends on lmdb0
+  so it can continue using existing wordlist.lmdb databases.
+
+  For users who wish to transition to LMDB 1.0.0, please:
+  - identify all wordlist.lmdb files, and
+  - for each of them, run:
+    bogoutil -d /path/to/wordlist.ldmb >/path/to/wordlist.txt
+  - THEN you can install to mail/bogofilter-lmdb1,
+  - for each of the wordlist.lmdb files, move them to a safe
+    place, and recreate them from the text file, i.e.
+    for each, run:
+    bogoutil -l /path/to/wordlist.lmdb </path/to/wordlist.txt
+
+  At a later point, we will upgrade mail/bogofilter to refer
+  to lmdb 1.0 and remove the bogofilter-lmdb1 port.
+
 20260702:
   AFFECTS: users of databases/lmdb
   AUTHOR: delphij@FreeBSD.org

--- a/mail/Makefile
+++ b/mail/Makefile
@@ -29,6 +29,7 @@
     SUBDIR += bmf
     SUBDIR += bogofilter
     SUBDIR += bogofilter-kc
+    SUBDIR += bogofilter-lmdb1
     SUBDIR += bogofilter-sqlite
     SUBDIR += bsd-vacation
     SUBDIR += bsfilter

--- a/mail/bogofilter-kc/Makefile
+++ b/mail/bogofilter-kc/Makefile
@@ -1,20 +1,21 @@
 PORTNAME=	bogofilter
 PORTREVISION=	1
-CATEGORIES=	mail
 PKGNAMESUFFIX=	-kc
 
-MAINTAINER=	mandree@FreeBSD.org
 COMMENT=	Fast, teachable, learning spam detector (KyotoCabinet database)
+
+DEPRECATED=	# override master port
 
 LIB_DEPENDS=	libkyotocabinet.so:databases/kyotocabinet
 
-CONFLICTS_INSTALL=	bogofilter bogofilter-bdb bogofilter-sqlite  # bogofilter-bdb is historic, but let's keep this for a while
-
 CONFIGURE_ARGS=	--with-database=kyotocabinet
-BF_CPPFLAGS=	-I${LOCALBASE}/include
-BF_LIBS=
-DESCR=		${PKGDIR}/pkg-descr
+
+CONFLICTS_INSTALL=	bogofilter bogofilter-lmdb1 bogofilter-sqlite
 
 MASTERDIR=	${.CURDIR}/../bogofilter
+DESCR=		${PKGDIR}/pkg-descr
+
+BF_CPPFLAGS=	-I${LOCALBASE}/include
+BF_LIBS=
 
 .include "${MASTERDIR}/Makefile"

--- a/mail/bogofilter-lmdb1/Makefile
+++ b/mail/bogofilter-lmdb1/Makefile
@@ -1,0 +1,23 @@
+PORTNAME=	bogofilter
+PORTREVISION=	0
+PKGNAMESUFFIX=	-lmdb1
+
+COMMENT=	Fast, teachable, learning spam detector (LMDB 1.0 database)
+
+DEPRECATED=	This port will be renamed to bogofilter at some point, see UPDATING
+# at the same time, bogofilter shall update from lmdb0 to lmdb (1.0)
+EXPIRATION_DATE=2026-12-31
+
+LIB_DEPENDS=	liblmdb.so.1:databases/lmdb
+
+CONFIGURE_ARGS=	--with-database=lmdb
+
+CONFLICTS_INSTALL=	bogofilter bogofilter-kc bogofilter-sqlite
+
+MASTERDIR=	${.CURDIR}/../bogofilter
+DESCR=		${PKGDIR}/pkg-descr
+
+BF_CPPFLAGS=	-I${LOCALBASE}/include
+BF_LIBS=
+
+.include "${MASTERDIR}/Makefile"

--- a/mail/bogofilter-sqlite/Makefile
+++ b/mail/bogofilter-sqlite/Makefile
@@ -1,19 +1,20 @@
 PORTNAME=	bogofilter
 PORTREVISION=	1
-CATEGORIES=	mail
 PKGNAMESUFFIX=	-sqlite
 
-MAINTAINER=	mandree@FreeBSD.org
 COMMENT?=	Fast, teachable, learning spam detector (SQLite3 database)
 
+DEPRECATED=	# override master port
+
 USES=		sqlite
-CONFLICTS_INSTALL=	bogofilter bogofilter-bdb bogofilter-kc  # bogofilter-bdb is historic, but let's keep this for a while
 
 CONFIGURE_ARGS=	--with-database=sqlite
-BF_CPPFLAGS=	-I${LOCALBASE}/include
-BF_LIBS=
+
+CONFLICTS_INSTALL=	bogofilter bogofilter-kc bogofilter-lmdb1
+MASTERDIR=	${.CURDIR}/../bogofilter
 DESCR=		${PKGDIR}/pkg-descr
 
-MASTERDIR=	${.CURDIR}/../bogofilter
+BF_CPPFLAGS=	-I${LOCALBASE}/include
+BF_LIBS=
 
 .include "${MASTERDIR}/Makefile"

--- a/mail/bogofilter/Makefile
+++ b/mail/bogofilter/Makefile
@@ -1,49 +1,55 @@
 PORTNAME=	bogofilter
 DISTVERSION=	1.3.0.rc1
-PORTREVISION?=	2
+PORTREVISION?=	3
 CATEGORIES?=	mail
 MASTER_SITES=	SF/bogofilter/bogofilter-current/bogofilter-1.3.0.beta/ \
 		https://gitlab.com/-/project/12408342/uploads/647db3bd2f28a1f91bdd3bb1945d91fe/
-PKGNAMESUFFIX?=	# blank by default, and ?= so slave ports can override
 
-MAINTAINER?=	mandree@FreeBSD.org
-COMMENT?=	Fast, teachable, learning spam detector (LMDB database)
+MAINTAINER=	mandree@FreeBSD.org
+COMMENT?=	Fast, teachable, learning spam detector (LMDB 0.9 database)
 WWW=		https://bogofilter.sourceforge.io/
 
-LICENSE=	GPLv2
+LICENSE=	GPLv2+
+
+DEPRECATED?=	This port will update to LMDB 1.0. Please transition to bogofilter-lmdb1 before December 2026, see UPDATING
+# no EXPIRATION_DATE, we don't intend to remove this.
+# The plan is: at the same time as bogofilter-lmdb1 expires, upgrade this port to LMDB 1.0.
+
+USES+=		cpe perl5 shebangfix tar:xz
+CPE_VENDOR=	bogofilter_project
+USE_PERL5=	run
+
+SHEBANG_FILES=	contrib/randomtrain.sh contrib/scramble.sh \
+		src/tests/unsort.pl contrib/*.pl
+GNU_CONFIGURE=	yes
+
+TEST_TARGET=	check
+
+CONFLICTS_INSTALL?=	bogofilter-kc bogofilter-lmdb1 bogofilter-sqlite
+
+PORTDOCS=	*
 
 OPTIONS_DEFINE=		GSL UNICODE DOCS
 OPTIONS_DEFAULT=	GSL UNICODE
 GSL_DESC=		Link with system-wide GSL dynamically (recommended)
 UNICODE_DESC=		Normalize tokens to Unicode (UTF-8) (recommended)
 
-CONFLICTS_INSTALL?=	bogofilter-bdb bogofilter-kc bogofilter-lmdb bogofilter-sqlite  # bogofilter-bdb and -lmdb are historic, but let's keep them for a while
-
-USES+=		cpe perl5 shebangfix tar:xz
-SHEBANG_FILES=	contrib/randomtrain.sh contrib/scramble.sh \
-		src/tests/unsort.pl contrib/*.pl
-USE_PERL5=	run
-GNU_CONFIGURE=	yes
-
-CPE_VENDOR=	bogofilter_project
-
-UNICODE_USES=	iconv
-UNICODE_CONFIGURE_ENABLE=	unicode
 GSL_LIB_DEPENDS=	libgsl.so:math/gsl
 GSL_CONFIGURE_OFF=	--with-included-gsl
 
-PORTDOCS=	*
-
-TEST_TARGET=	check
+UNICODE_USES=	iconv
+UNICODE_CONFIGURE_ENABLE=	unicode
 
 .include <bsd.port.pre.mk>
 
 BF_CPPFLAGS?=		-I${LOCALBASE}/include
 BF_LIBS?=		# empty, can be passed in by slave ports
 CONFIGURE_ARGS+=	--sysconfdir=${PREFIX}/etc
-.if !defined(MASTERDIR) || ${MASTERDIR} == ${.CURDIR}
+
+.if ${MASTERDIR} == ${.CURDIR}
+# we're building the master port
 CONFIGURE_ARGS+=	--with-database=lmdb
-LIB_DEPENDS=   liblmdb.so:databases/lmdb0
+LIB_DEPENDS+=	liblmdb.so.0:databases/lmdb0
 .endif
 .if ${PORT_OPTIONS:MUNICODE}
 BF_LIBS+=		${ICONV_LIB}

--- a/mail/bogofilter/files/patch-contrib__trainbogo.sh
+++ b/mail/bogofilter/files/patch-contrib__trainbogo.sh
@@ -1,6 +1,6 @@
---- ./contrib/trainbogo.sh.orig	2007-07-24 00:44:06.000000000 +0200
-+++ ./contrib/trainbogo.sh	2011-08-31 12:15:20.000000000 +0200
-@@ -181,7 +181,7 @@
+--- contrib/trainbogo.sh.orig	2025-04-04 13:02:33 UTC
++++ contrib/trainbogo.sh
+@@ -178,7 +178,7 @@ if [ ! -f "${list}" ] || [ -n "${dofilelist}" ]; then
      for i in "${hamdir}"/* "${spamdir}"/*
        do
        [ ! -f "${i}" ] && continue

--- a/mail/bogofilter/files/patch-src_datastore__lmdb.c
+++ b/mail/bogofilter/files/patch-src_datastore__lmdb.c
@@ -1,0 +1,26 @@
+From 3cee1c59bc937597b496fea5e7df84a2db9989ea Mon Sep 17 00:00:00 2001
+From: Matthias Andree <matthias.andree@gmx.de>
+Date: Thu, 2 Jul 2026 23:26:06 +0200
+Subject: [PATCH] LMDB: call mdb_env_get_maxkeysize() after mdb_env_open()
+
+LMDB 1.0.0 would otherwise return 0 and we'd ignore our entire database
+--- src/datastore_lmdb.c.orig	2025-04-09 19:50:41 UTC
++++ src/datastore_lmdb.c
+@@ -202,8 +202,6 @@ a_bflm_init(bfpath *bfp, bool rdonly){
+         goto jerr1;
+     }
+ 
+-    rv->bflm_maxkeysize = mdb_env_get_maxkeysize(rv->bflm_env);
+-
+     /* To accommodate bogofilter's db_created() mechanism, we cannot use the 
+      * unnamed DB which "always exists", but must place data in named ones */
+     e = mdb_env_set_maxdbs(rv->bflm_env, 2);
+@@ -230,6 +228,8 @@ a_bflm_init(bfpath *bfp, bool rdonly){
+         emsg = "mdb_env_open()";
+         goto jerr2;
+     }
++
++    rv->bflm_maxkeysize = mdb_env_get_maxkeysize(rv->bflm_env);
+ 
+     /* Let us fake a "has been created" event :( */
+     if(!(rv->bflm_flags & a_BFLM_RDONLY) &&


### PR DESCRIPTION
Here's what we do now:
- mail/bogofilter currently depends on lmdb0, a 0.9.X port, so it continues to work as before
- add a new mail/bogofilter-lmdb1 port that depends on lmdb, the 1.0 version of the LMDB database.
- add the upstream patch for bogofilter 1.3.0.rc1 that I made and that delphij@ prepared for integration into the ports tree - thanks!

Here's the plan for end of 2026:
- AT THE SAME TIME:
   - upgrade mail/bogofilter to depend on LMDB 1.0
   - portrm mail/bogofilter-lmdb1
   - add a MOVED entry to redirect from bogofilter-lmdb1 to bogofilter.

PR:		296519