### PR TITLE
Mk/Scripts/qa.sh: readelf 1 file a time, baselibs()

### DIFF
--- a/Mk/Scripts/qa.sh
+++ b/Mk/Scripts/qa.sh
@@ -136,7 +136,7 @@ baselibs() {
 			;;
 		esac
 	done <<-EOF
-	$(list_stagedir_elfs -exec readelf -d {} + 2>/dev/null)
+	$(list_stagedir_elfs -exec readelf -d {} \; 2>/dev/null)
 	EOF
 
 	if ! list_stagedir_elfs | egrep -q 'lib(crypto|ssl).so*'; then


### PR DESCRIPTION
    ...to repair detection of libssl/libcrypto usage inside a port,
    to avoid a bogus "you may not need USES=ssl" warning from stage-qa
    in ports that have USES=ssl and that do dynamically link against
    libcrypto.so or libssl.so.
    
    The cause is that the script currently feeds many files to readelf -d,
    in lexiographical order from find -s, and might feed non-ELF
    executables, such as scripts. In that case, readelf aborts without looking
    at any other file, and the error message is sent 2>/dev/null,
    we and may miss those files later in the list that do use crypto/ssl.
    
    Fix: feed files individually to readelf -d
    to make sure it really looks at each of them.
    
    PR:             296889
    Fixes:          cfff850 Make baselibs QA check non recursive and activate it again
    (The ldd -a used before the earlier more lenient and would process all files.)
