### PR TITLE
graphics/d2: Update source repository

### DIFF
--- a/graphics/d2/Makefile
+++ b/graphics/d2/Makefile
@@ -12,7 +12,7 @@ LICENSE=	MPL20
 LICENSE_FILE=	${WRKSRC}/LICENSE.txt
 
 USES=		go:modules
-GO_MODULE=	github.com/terrastruct/d2
+GO_MODULE=	github.com/d2lang/d2
 
 PLIST_FILES=	bin/d2
 

--- a/graphics/d2/distinfo
+++ b/graphics/d2/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1755614907
+TIMESTAMP = 1785641797
 SHA256 (go/graphics_d2/d2-v0.7.1/v0.7.1.mod) = 3e80ff104186c4966c030fd807ef143fed3e92d551a7da48b1ffbbc830624810
 SIZE (go/graphics_d2/d2-v0.7.1/v0.7.1.mod) = 2278
-SHA256 (go/graphics_d2/d2-v0.7.1/v0.7.1.zip) = 0793db1dcb02a011f278d2c01f870eeb04d941464f64ed1d376d1b22eda257f8
-SIZE (go/graphics_d2/d2-v0.7.1/v0.7.1.zip) = 32485253
+SHA256 (go/graphics_d2/d2-v0.7.1/v0.7.1.zip) = c8423f767c37b390b3f2044d928d8a5b74ef6225d56ae90f01b57cafc3060002
+SIZE (go/graphics_d2/d2-v0.7.1/v0.7.1.zip) = 33669798


### PR DESCRIPTION
D2's GitHub repository moved from the Terrastruct organization to `d2lang`. Update `GO_MODULE` to the new repository path and refresh `distinfo` for the changed Go proxy ZIP prefix.

The `v0.7.1` tag object and peeled commit are identical at the old and new GitHub URLs. The extracted Go proxy source trees are also identical after removing their module-path directory prefixes, and the upstream `go.mod` still declares `oss.terrastruct.com/d2`.

Validation:

- `portlint -C graphics/d2` passed using portable bmake.
- FreeBSD's `Mk/Scripts/checksum.sh` accepted both refreshed module distfiles.
- `git diff --check` passed.
- A full FreeBSD package build was not run because this host is macOS.
