### PR TITLE
net/reliable: Update to 1.4.0

### DIFF
--- a/net/reliable/Makefile
+++ b/net/reliable/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	reliable
 DISTVERSIONPREFIX=	v
-DISTVERSION=	1.3.4
+DISTVERSION=	1.4.0
 CATEGORIES=	net devel
 
 MAINTAINER=	glenn@mas-bandwidth.com

--- a/net/reliable/distinfo
+++ b/net/reliable/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1783803913
-SHA256 (mas-bandwidth-reliable-v1.3.4_GH0.tar.gz) = 1f3e8cda9780aad3582f267b4728690d1b570d205e620f0596006df9d27d92cb
-SIZE (mas-bandwidth-reliable-v1.3.4_GH0.tar.gz) = 35116
+TIMESTAMP = 1785885468
+SHA256 (mas-bandwidth-reliable-v1.4.0_GH0.tar.gz) = bcd4e55fc9ea3108d68a30a1a7ecdcf02d0cfe7e6144e4f1a10b06a6e37529b6
+SIZE (mas-bandwidth-reliable-v1.4.0_GH0.tar.gz) = 46334


### PR DESCRIPTION
Update net/reliable 1.3.4 -> 1.4.0.

Routine upstream release; install rules unchanged, plist self-tracking (SOVERSION 1, `lib/libreliable.so.${DISTVERSION}`). Checksums computed from the GitHub codeload tarball and reproduce the committed distinfo values for the previous version via the same fetch path; please confirm with `make makesum`.

Submitter is the maintainer (glenn@mas-bandwidth.com).