### PR TITLE
devel/serialize: Update to 1.5.0

### DIFF
--- a/devel/serialize/Makefile
+++ b/devel/serialize/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	serialize
 DISTVERSIONPREFIX=	v
-DISTVERSION=	1.4.3
+DISTVERSION=	1.5.0
 CATEGORIES=	devel
 
 MAINTAINER=	glenn@mas-bandwidth.com

--- a/devel/serialize/distinfo
+++ b/devel/serialize/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1783803913
-SHA256 (mas-bandwidth-serialize-v1.4.3_GH0.tar.gz) = 4be561172300962ccb340ae7f7904882700ee79a20a698979cce5097310eeaae
-SIZE (mas-bandwidth-serialize-v1.4.3_GH0.tar.gz) = 41961
+TIMESTAMP = 1785885468
+SHA256 (mas-bandwidth-serialize-v1.5.0_GH0.tar.gz) = 78c73a8eeee45a02208c2acfda734918d378a2204c0319233ab9d43623c8bbdd
+SIZE (mas-bandwidth-serialize-v1.5.0_GH0.tar.gz) = 55161


### PR DESCRIPTION
Update devel/serialize 1.4.3 -> 1.5.0.

Routine upstream release; the three PLIST_FILES entries verified unchanged against the 1.5.0 CMake install rules (the only non-version CMake change is an MSVC-only test flag). Checksums computed from the GitHub codeload tarball and reproduce the committed distinfo values for the previous version via the same fetch path; please confirm with `make makesum`.

Submitter is the maintainer (glenn@mas-bandwidth.com).