### PR TITLE
x11/plasma6-plasma-desktop: Fix installation with XLibre.

### DIFF
--- a/x11/plasma6-plasma-desktop/Makefile
+++ b/x11/plasma6-plasma-desktop/Makefile
@@ -37,8 +37,7 @@ USE_KDE=	activities activities-stats attica auth baloo bookmarks \
 USE_QT=		5compat base declarative svg wayland
 USE_XORG=	x11 xcb xcursor xext xfixes xi xrender
 
-OPTIONS_DEFINE=		SDL X11
-OPTIONS_DEFAULT=	X11
+OPTIONS_DEFINE=		SDL
 OPTIONS_GROUP=		IM
 IM_DESC=		Input Method Support
 OPTIONS_GROUP_IM=	IBUS SCIM
@@ -56,7 +55,5 @@ SDL_DESC=		Enable gamecontroller System Settings module
 SDL_USES=		sdl
 SDL_USE=		sdl=sdl2
 SDL_CMAKE_BOOL_OFF=	CMAKE_DISABLE_FIND_PACKAGE_SDL2
-
-X11_RUN_DEPENDS=	xf86-input-libinput>0:x11-drivers/xf86-input-libinput
 
 .include <bsd.port.mk>


### PR DESCRIPTION
This is a follow up of PR [291602](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291602).

This issue was known [before XLibre was added to the ports tree](https://forums.freebsd.org/threads/porting-x11libre-to-freebsd.98455/post-711358), and we created the above PR, right after the XLibre merger to resolve it. Unfortunately the resulting changes didn't address the core issue[^1], so I created this GitHub PR as a follow-up.

In short, the problem is a **_runtime_** dependency conflict between `x11/kde` and `x11-servers/xlibre-server`, and it plays out like this:

* `x11/kde`: Depends in runtime on `x11/plasma6-plasma-desktop`
* `x11/plasma6-plasma-desktop`: $${\color{red} Depends\space in\space runtime\space on\space}$$ `x11-drivers/xf86-input-libinput`
* `x11-drivers/xf86-input-libinput`: Depends in runtime on `x11-servers/xorg-server`
* `x11-servers/xorg-server`: Totally conflicts with `x11-servers/xlibre-server`

Hence `x11/kde` conflicts with `x11-servers/xlibre-server` in runtime.

The conflict is reproducible by first installing `x11-servers/xlibre-server` with `pkg` on a test system/jail and then trying to install `x11/kde`.
After `pkg` fetches all the required dependencies and tries to install `x11-servers/xorg-server`, it prompts the user to remove the entirety of their XLibre installation.



To fix this issue, initially an admittedly more invasive method of `FLAVOR`izing the KDE ports was suggested, but that's __*NOT*__ what's being suggested here. Shortly after, we rethought the approach and [suggested this current solution](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291602#c4): that is to simply remove the **_runtime_** dependency of `x11/plasma6-plasma-desktop` on `x11-drivers/xf86-input-libinput` which is the key link in this conflict.
KDE plasma-desktop requires a header file from `x11-drivers/xf86-input-libinput` during build time **_only_**. There is nothing in KDE that would require it to be present in runtime. So it would be best to make `plasma-desktop` depend on `xf86-input-libinput` at build time **_only_** as you can see in the patch.

I also had a look at several Linux distributions, and they all do the same:

* Arch Linux: [Only a makedepend.](https://gitlab.archlinux.org/archlinux/packaging/packages/plasma-desktop/-/blob/main/PKGBUILD?ref_type=heads)
* Void Linux: [Only a makedepend.](https://github.com/void-linux/void-packages/blob/2d71a83cc9962ba8f97123b0f58738f42fdae5aa/srcpkgs/plasma-desktop/template#L24)
* Debian: [Only a builddepend.](https://sources.debian.org/src/plasma-desktop/4%3A6.7.2-1/debian/control#L95)
* Alpine: [Only a makedepend.](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/plasma-desktop/APKBUILD#L67)

In the past 8 months, there have been quite a few cases of people trying to install KDE+XLibre, and facing this exact issue. Some examples:

[Graham Perrin on r/FreeBSD](https://old.reddit.com/r/freebsd/comments/1qgcihy/x11/o0cv1bj/)
[User on FBSD forums](https://forums.freebsd.org/threads/pkg-upgrade-tries-to-remove-kde.101537/post-742735)
[Another user on the FBSD forums](https://forums.freebsd.org/threads/porting-x11libre-to-freebsd.98455/post-734948)
[Blog detailing Installation of FBSD on a 2012 Macbook](https://joe.linuxdojo.org/projects/freebsd-macbook-pro-2012/#xlibre:~:text=pkg%27s,server%2E)

Given the circumstances, I'd like to kindly ask you to merge the PR. If possible, a back-port to Q3 would be appreciated so that the solution can be made available to users sooner.

CC @alonsobsd @DtxdF

[^1]: After PR [291602](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291602) was closed, commit [11923b7](https://github.com/freebsd/freebsd-ports/commit/11923b719e13d223cab5484cdf9629aee15e37da) was made referencing it. The changes unfortunately continued to impose a runtime dependency on `x11-drivers/xf86-input-libinput` in the resulting package, and [our follow-up](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291602#c6) remained unanswered.
