### PR TITLE
graphics/openexr*: security update to 3.4.14

### DIFF
--- a/graphics/openexr-website-docs/Makefile
+++ b/graphics/openexr-website-docs/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	openexr-website-docs
-DISTVERSION=	3.4.13
-PORTREVISION=	1
+DISTVERSION=	3.4.14
+PORTREVISION=	0
 MASTER_SITES=	https://github.com/AcademySoftwareFoundation/openexr/releases/download/v${DISTVERSION}/:DEFAULT \
 		https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main/:website \
 		LOCAL/mandree/openexr/:DEFAULT \

--- a/graphics/openexr-website-docs/distinfo
+++ b/graphics/openexr-website-docs/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1781941135
-SHA256 (openexr/openexr-3.4.13.tar.gz) = fe99c9cf06e41803db75ae4f5c9bb9955b7033ff47f05b02bc60bc5dba391996
-SIZE (openexr/openexr-3.4.13.tar.gz) = 25783727
+TIMESTAMP = 1786564614
+SHA256 (openexr/openexr-3.4.14.tar.gz) = 174d0d711d963c46eaa7cd2669d6cb1ea52579f43aa2726892f0b9554339ba6b
+SIZE (openexr/openexr-3.4.14.tar.gz) = 25838337
 SHA256 (openexr/TestImages/README.rst) = 3cbb0a9ab20868940de1b9bf582bdc5ff4244cc585c682d6e40b9befb8fd593c
 SIZE (openexr/TestImages/README.rst) = 2588
 SHA256 (openexr/TestImages/AllHalfValues.exr) = eede573a0b59b79f21de15ee9d3b7649d58d8f2a8e7787ea34f192db3b3c84a4

--- a/graphics/openexr/Makefile
+++ b/graphics/openexr/Makefile
@@ -1,6 +1,6 @@
 PORTNAME?=	openexr
-DISTVERSION?=	3.4.13 # ALSO update openexr-website-docs! -- verify sigstore: make makesum verify-sigstore
-PORTREVISION?=	1
+DISTVERSION?=	3.4.14 # ALSO update openexr-website-docs! -- verify sigstore: make makesum verify-sigstore
+PORTREVISION?=	0
 CATEGORIES=	graphics devel
 .if !defined(MASTERDIR)
 MASTER_SITES=	https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/v1.0/:testimages \

--- a/graphics/openexr/distinfo
+++ b/graphics/openexr/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1781941135
-SHA256 (openexr/openexr-3.4.13.tar.gz) = fe99c9cf06e41803db75ae4f5c9bb9955b7033ff47f05b02bc60bc5dba391996
-SIZE (openexr/openexr-3.4.13.tar.gz) = 25783727
+TIMESTAMP = 1786562953
+SHA256 (openexr/openexr-3.4.14.tar.gz) = 174d0d711d963c46eaa7cd2669d6cb1ea52579f43aa2726892f0b9554339ba6b
+SIZE (openexr/openexr-3.4.14.tar.gz) = 25838337
 SHA256 (openexr/Beachball/multipart.0001.exr) = 0cd032069fbaa14a2766861fef9893ea66a6494ff64650725d3b26a500df774b
 SIZE (openexr/Beachball/multipart.0001.exr) = 2894260
 SHA256 (openexr/Beachball/singlepart.0001.exr) = 29719942ed3c095a8f8f111fc139fc4c28f446007f5bfce00177cae585b1a87a


### PR DESCRIPTION
Note there is a compiler warning about a const-ness being cast away in one place.  This has been reported upstream, and appears safe because the data that's made const in the interim was just read into an underlying array, so the referenced data is actually writable, see https://github.com/AcademySoftwareFoundation/openexr/pull/2593/commits/0c5d5b8a2547d62b2da2368ef4d01cd15d024d53

Litte-endian computers such as x86_64 are safe either way.

See man 7 arch about architecture, or the online rendering at https://man.freebsd.org/cgi/man.cgi?query=arch&apropos=0&sektion=7&format=html

Changelog:	https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.14

Security:	CVE-2026-68514 PyOpenEXR deep prefixed literal RGB key collision heap buffer overflow
Security:	CVE-2026-68513 PyOpenEXR prefixed literal RGB key collision heap buffer overflow
Security:	CVE-2026-62986 PyOpenEXR deep prefixed RGB stale lane disclosure
Security:	CVE-2026-61703 PyOpenEXR deep mixed RGB heap buffer overflow
Security:	CVE-2026-61555 empty multiView viewFromChannelName file crash
Security:	CVE-2026-59985 ILP32 OpenEXRCore RLE decode heap OOB read DoS
Security:	CVE-2026-59984 ILP32 B44 InputFile decode scratch buffer overflow
Security:	CVE-2026-59983 ILP32 DeepTiledInputFile sample count table decode OOB read
Security:	CVE-2026-59982 ILP32 DWAA InputFile packed AC buffer overflow
Security:	CVE-2026-59981 OpenEXRUtil SampleCountChannel row nonzero dataWindow heap OOB read
Security:	CVE-2026-59189 OpenEXRUtil DeepImageChannel row nonzero dataWindow heap OOB read
Security:	CVE-2026-59187 OpenEXR exrmetrics deep pixelmode heap buffer overflow
Security:	CVE-2026-59186 OpenEXR ILP32 TiledRgbaInputFile large tile Array2D heap OOB write
Security:	CVE-2026-59184 OpenEXRUtil FlatImageChannel row nonzero dataWindow heap OOB write
Security:	CVE-2026-59183 Signed Integer Overflow Leading to Out-of-Bounds Memory Access in Deep Tile Decoding
MFH:		2026Q3
PR:		297486