### PR TITLE
security/openvpn: bugfix update to 2.7.6

### DIFF
--- a/security/openvpn/Makefile
+++ b/security/openvpn/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=		openvpn
-DISTVERSION=		2.7.5
-PORTREVISION=		1
+DISTVERSION=		2.7.6
+PORTREVISION=		0
 CATEGORIES=		security net net-vpn
 MASTER_SITES=		https://swupdate.openvpn.org/community/releases/ \
 			https://build.openvpn.net/downloads/releases/

--- a/security/openvpn/distinfo
+++ b/security/openvpn/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782925053
-SHA256 (openvpn-2.7.5.tar.gz) = c6864b3c7d4e059c7d6ce22d1b5fa646c8b379a06af872eeb9792b6083a44ac4
-SIZE (openvpn-2.7.5.tar.gz) = 2101063
+TIMESTAMP = 1786867665
+SHA256 (openvpn-2.7.6.tar.gz) = 10e24a9385f23cc38cc5cf448f3ca0769f939bc4cbecc4f4647d7e006e52db74
+SIZE (openvpn-2.7.6.tar.gz) = 2105678


### PR DESCRIPTION
This is not security-relevant on FreeBSD, one security fix affects Windows, the other one only affects builds against mbedTLS (which is not currently supported by the port), and a third one (second bullet point) turned out to not be exploitable.

Note that the --dev option defaults to "tun" (if not specified).

Note that --ping and --keepalive settings are now capped at 24 h.

TCP-based configurations now always enable TCP_NODELAY.

Changelog:	https://github.com/OpenVPN/openvpn/releases/tag/v2.7.6
MFH:		2026Q3