### PR TITLE
graphics/openexr*: security fix update to v3.4.15

### DIFF
--- a/graphics/openexr-website-docs/Makefile
+++ b/graphics/openexr-website-docs/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	openexr-website-docs
-DISTVERSION=	3.4.14
+DISTVERSION=	3.4.15
 PORTREVISION=	0
 MASTER_SITES=	https://github.com/AcademySoftwareFoundation/openexr/releases/download/v${DISTVERSION}/:DEFAULT \
 		https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main/:website \

--- a/graphics/openexr-website-docs/distinfo
+++ b/graphics/openexr-website-docs/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1786564614
-SHA256 (openexr/openexr-3.4.14.tar.gz) = 174d0d711d963c46eaa7cd2669d6cb1ea52579f43aa2726892f0b9554339ba6b
-SIZE (openexr/openexr-3.4.14.tar.gz) = 25838337
+TIMESTAMP = 1787353806
+SHA256 (openexr/openexr-3.4.15.tar.gz) = ab893d8003773ccd9a5556b2caf38da591ae37e20b06ee9d589a08984c5191f2
+SIZE (openexr/openexr-3.4.15.tar.gz) = 25840011
 SHA256 (openexr/TestImages/README.rst) = 3cbb0a9ab20868940de1b9bf582bdc5ff4244cc585c682d6e40b9befb8fd593c
 SIZE (openexr/TestImages/README.rst) = 2588
 SHA256 (openexr/TestImages/AllHalfValues.exr) = eede573a0b59b79f21de15ee9d3b7649d58d8f2a8e7787ea34f192db3b3c84a4

--- a/graphics/openexr/Makefile
+++ b/graphics/openexr/Makefile
@@ -1,5 +1,5 @@
 PORTNAME?=	openexr
-DISTVERSION?=	3.4.14 # ALSO update openexr-website-docs! -- verify sigstore: make makesum verify-sigstore
+DISTVERSION?=	3.4.15 # ALSO update openexr-website-docs! -- verify sigstore: make makesum verify-sigstore
 PORTREVISION?=	0
 CATEGORIES=	graphics devel
 .if !defined(MASTERDIR)

--- a/graphics/openexr/distinfo
+++ b/graphics/openexr/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1786562953
-SHA256 (openexr/openexr-3.4.14.tar.gz) = 174d0d711d963c46eaa7cd2669d6cb1ea52579f43aa2726892f0b9554339ba6b
-SIZE (openexr/openexr-3.4.14.tar.gz) = 25838337
+TIMESTAMP = 1787352131
+SHA256 (openexr/openexr-3.4.15.tar.gz) = ab893d8003773ccd9a5556b2caf38da591ae37e20b06ee9d589a08984c5191f2
+SIZE (openexr/openexr-3.4.15.tar.gz) = 25840011
 SHA256 (openexr/Beachball/multipart.0001.exr) = 0cd032069fbaa14a2766861fef9893ea66a6494ff64650725d3b26a500df774b
 SIZE (openexr/Beachball/multipart.0001.exr) = 2894260
 SHA256 (openexr/Beachball/singlepart.0001.exr) = 29719942ed3c095a8f8f111fc139fc4c28f446007f5bfce00177cae585b1a87a


### PR DESCRIPTION
"v3.4.15 fixes two memory issues when parsing IDManifests. Corrupt or maliciously formed OpenEXR images could trigger excessive memory allocation, but only in code which decodes the idmanifest attribute. Other code is unaffected, even when handling files with idmanifest attributes [...] CVEs have been requested for these issues." <https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.15>

CVEs are not yet communicated.

Changelog:	https://github.com/AcademySoftwareFoundation/openexr/blob/v3.4.15/CHANGES.md#version-3415-august-21-2026

MFH:		2026Q3
PR:		297717