### PR TITLE
misc/llama-model: new port

### DIFF
--- a/misc/Makefile
+++ b/misc/Makefile
@@ -288,6 +288,7 @@
     SUBDIR += linux-rl9-sdl12-extralibs
     SUBDIR += linux-rl9-sdl20-extralibs
     SUBDIR += llama-cpp
+    SUBDIR += llama-model
     SUBDIR += locale-en_DK
     SUBDIR += localedata
     SUBDIR += logsurfer

--- a/misc/llama-model/Makefile
+++ b/misc/llama-model/Makefile
@@ -1,0 +1,51 @@
+PORTNAME=	llama-model
+DISTVERSION=	0.3.0
+CATEGORIES=	misc
+
+MAINTAINER=	dennis.r.friedrichsen@gmail.com
+COMMENT=	Manage and run local GGUF models with llama-server
+WWW=		https://github.com/dennisfriedrichsen/llama-model
+
+LICENSE=	BSD2CLAUSE
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+RUN_DEPENDS=	llama-server:misc/llama-cpp
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	dennisfriedrichsen
+
+NO_ARCH=	yes
+NO_BUILD=	yes
+
+PLIST_FILES=	bin/llama-model \
+		share/man/man1/llama-model.1.gz
+
+OPTIONS_DEFINE=		DOCS EXAMPLES
+OPTIONS_DEFAULT=	EXAMPLES
+
+PORTDOCS=	README.md
+PORTEXAMPLES=	llama-models.conf server.args
+
+.include <bsd.port.options.mk>
+
+post-patch:
+	@${REINPLACE_CMD} 's|^VERSION=dev$$|VERSION=${DISTVERSION}|' \
+		${WRKSRC}/llama-model
+
+do-install:
+	${INSTALL_SCRIPT} ${WRKSRC}/llama-model ${STAGEDIR}${PREFIX}/bin/llama-model
+	${INSTALL_MAN} ${WRKSRC}/llama-model.1 \
+		${STAGEDIR}${PREFIX}/share/man/man1/llama-model.1
+.if ${PORT_OPTIONS:MDOCS}
+	@${MKDIR} ${STAGEDIR}${DOCSDIR}
+	${INSTALL_DATA} ${WRKSRC}/README.md ${STAGEDIR}${DOCSDIR}/
+.endif
+.if ${PORT_OPTIONS:MEXAMPLES}
+	@${MKDIR} ${STAGEDIR}${EXAMPLESDIR}
+	${INSTALL_DATA} ${WRKSRC}/llama-models.conf.example \
+		${STAGEDIR}${EXAMPLESDIR}/llama-models.conf
+	${INSTALL_DATA} ${WRKSRC}/server.args.example \
+		${STAGEDIR}${EXAMPLESDIR}/server.args
+.endif
+
+.include <bsd.port.mk>

--- a/misc/llama-model/distinfo
+++ b/misc/llama-model/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1787401916
+SHA256 (dennisfriedrichsen-llama-model-0.3.0_GH0.tar.gz) = f78434eb00ac66ed5f4316772b25948677bcba06b69eec84fc681c1293a24d9d
+SIZE (dennisfriedrichsen-llama-model-0.3.0_GH0.tar.gz) = 12060

--- a/misc/llama-model/pkg-descr
+++ b/misc/llama-model/pkg-descr
@@ -1,0 +1,11 @@
+llama-model is a POSIX sh wrapper around llama.cpp's llama-server. It gives
+local GGUF model files short, stable aliases and assembles the right
+llama-server invocation - model path, mmproj path, and layered argument
+files - for each alias.
+
+Each alias is a directory under a catalog root containing a symlink to the
+downloaded model file (and, for a vision model, a second symlink to its
+multimodal projector), so a model keeps its descriptive download name while
+commands use a memorable alias. Models can also be run detached as
+background services, with commands to list, start, stop, restart, and tail
+their logs.


### PR DESCRIPTION
## Description

llama-model is a POSIX sh wrapper around llama.cpp's llama-server. It gives
local GGUF model files short, stable aliases and assembles the right
llama-server invocation - model path, mmproj path, and layered argument
files - for each alias. Each alias is a directory under a catalog root
containing a symlink to the downloaded model file (and, for a vision model,
a second symlink to its multimodal projector), so a model keeps its
descriptive download name while commands use a memorable alias. Models can
also be run detached as background services, with commands to list, start,
stop, restart, and tail their logs.

WWW: https://github.com/dennisfriedrichsen/llama-model

## Testing

- [x] `portlint -A -C -DDEVELOPER=yes`: looks fine
- [x] `make checksubdirs` in misc/: clean (SUBDIR entry correctly placed/sorted)
- [x] Full `fetch` -> `checksum` -> `extract` -> `patch` -> `stage` -> `package` pipeline succeeds with no plist warnings
- [x] Installed the built package, ran `llama-model --version`, `man llama-model`, confirmed DOCS/EXAMPLES options install correctly, then cleanly uninstalled