### PR TITLE
devel/py-logbook: Add missing typing-extensions dependency

### DIFF
--- a/devel/py-logbook/Makefile
+++ b/devel/py-logbook/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	logbook
 PORTVERSION=	1.10.1
+PORTREVISION=	1
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -14,6 +15,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=  ${PYTHON_PKGNAMEPREFIX}setuptools-rust>0:devel/py-setuptools-rust@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}wheel>=0:devel/py-wheel@${PY_FLAVOR}
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}typing-extensions>=4.14.0:devel/py-typing-extensions@${PY_FLAVOR}
 
 USES=		cargo python
 USE_PYTHON=	autoplist concurrent pep517


### PR DESCRIPTION
@dch not sure what protocol is for something like this, a simple dep update to someone else's port

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=297885