### PR TITLE
math/clasp: Update to 3.4.1

### DIFF
--- a/math/clasp/Makefile
+++ b/math/clasp/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	clasp
-PORTVERSION=	3.3.9
+PORTVERSION=	3.4.1
 DISTVERSIONPREFIX=	v
 CATEGORIES=	math devel
 
@@ -14,7 +14,7 @@ USES=	compiler:c++11-lang cmake
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	potassco
-GH_TUPLE=	potassco:libpotassco:fa39da4:other/libpotassco
+GH_TUPLE=	potassco:libpotassco:a10b3ac:other/libpotassco
 
 PLIST_FILES=	bin/${PORTNAME}
 

--- a/math/clasp/distinfo
+++ b/math/clasp/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1693909958
-SHA256 (potassco-clasp-v3.3.9_GH0.tar.gz) = 858bb4850814a89e30711abea23985646fab56c8e43663a30b2255bb3d863948
-SIZE (potassco-clasp-v3.3.9_GH0.tar.gz) = 677796
-SHA256 (potassco-libpotassco-fa39da4_GH0.tar.gz) = a46dec9da76bc6af85060e47814b9c85cd80914fe3795e9c269608cb739289f3
-SIZE (potassco-libpotassco-fa39da4_GH0.tar.gz) = 259662
+TIMESTAMP = 1787735085
+SHA256 (potassco-clasp-v3.4.1_GH0.tar.gz) = c1eb1889248a7c221596588c0db774917cc835c309ce296de087d6ee2b1d11f1
+SIZE (potassco-clasp-v3.4.1_GH0.tar.gz) = 699910
+SHA256 (potassco-libpotassco-a10b3ac_GH0.tar.gz) = 2c41ea371a209601f4d1163db42437f9f033451a5f95db33c3be71b697275145
+SIZE (potassco-libpotassco-a10b3ac_GH0.tar.gz) = 263565


### PR DESCRIPTION
@vstakhov This fixes port's build against upcoming CMake 4.

`poudriere testport`ed on 15.1/amd64 and 14.5/i386.