### PR TITLE
multimedia/butt: fix build failure due to JACK

### DIFF
--- a/multimedia/butt/Makefile
+++ b/multimedia/butt/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	butt
 PORTVERSION=	1.47.0
+PORTREVISION=	1
 CATEGORIES=	multimedia graphics
 MASTER_SITES=	https://danielnoethen.de/butt/release/${PORTVERSION}/
 
@@ -30,6 +31,13 @@ USES=		autoreconf compiler:c++11-lang gettext \
 USE_XORG=	x11 xrender xcursor xfixes xext xft xinerama
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS+=	--enable-webrtc
+
+OPTIONS_DEFINE=	JACK
+
+JACK_DESC=	JACK audio server support via PortAudio
+JACK_CXXFLAGS=	-DHAVE_JACK
+JACK_LIB_DEPENDS=	libjack.so:audio/jack
+
 CFLAGS+=	-I/usr/local/include
 LDFLAGS+=	-L/usr/local/lib -lintl
 PLIST_FILES=	bin/butt \

--- a/multimedia/butt/files/patch-src_butt.cpp
+++ b/multimedia/butt/files/patch-src_butt.cpp
@@ -1,0 +1,20 @@
+--- src/butt.cpp.orig	2026-08-26 23:50:14 UTC
++++ src/butt.cpp
+@@ -561,7 +561,7 @@ int main(int argc, char *argv[])
+                 return 1;
+             }
+             break;
+-#if !defined(__APPLE__) && !defined(WIN32) && !defined(BUILD_CLIENT)
++#if !defined(__APPLE__) && !defined(WIN32) && !defined(BUILD_CLIENT) && defined(HAVE_JACK)
+         case 'j':
+             jack_client_name = (char *)malloc((strlen(optarg) + 1) * sizeof(char));
+             strcpy(jack_client_name, optarg);
+@@ -595,7 +595,7 @@ int main(int argc, char *argv[])
+                      "-m\tSet streaming silence threshold (seconds)\n"
+                      "-O\tSet recording signal threshold (seconds)\n"
+                      "-o\tSet recording silence threshold (seconds)\n"
+-#if !defined(__APPLE__) && !defined(WIN32)
++#if !defined(__APPLE__) && !defined(WIN32) && defined(HAVE_JACK)
+                      "-j\tSet jack name\n"
+ #endif
+                      "-U\tConnect via UDP instead of TCP\n"

--- a/multimedia/butt/files/patch-src_cfg.cpp
+++ b/multimedia/butt/files/patch-src_cfg.cpp
@@ -1,0 +1,11 @@
+--- src/cfg.cpp.orig	2026-08-26 23:50:43 UTC
++++ src/cfg.cpp
+@@ -39,7 +39,7 @@ char *cfg_path;
+ 
+ config_t cfg;
+ char *cfg_path;
+-#if !defined(__APPLE__) && !defined(WIN32)
++#if !defined(__APPLE__) && !defined(WIN32) && defined(HAVE_JACK)
+ char *jack_client_name;
+ #endif
+ 

--- a/multimedia/butt/files/patch-src_cfg.h
+++ b/multimedia/butt/files/patch-src_cfg.h
@@ -1,0 +1,11 @@
+--- src/cfg.h.orig	2026-08-26 23:50:52 UTC
++++ src/cfg.h
+@@ -394,7 +394,7 @@ extern config_t cfg;   // Holds config parameters
+ 
+ extern char *cfg_path; // Path to config file
+ extern config_t cfg;   // Holds config parameters
+-#if !defined(__APPLE__) && !defined(WIN32)
++#if !defined(__APPLE__) && !defined(WIN32) && defined(HAVE_JACK)
+ extern char *jack_client_name; // JACK client name
+ #endif
+ 

--- a/multimedia/butt/files/patch-src_port__audio.cpp
+++ b/multimedia/butt/files/patch-src_port__audio.cpp
@@ -1,0 +1,20 @@
+--- src/port_audio.cpp.orig	2026-08-26 23:51:36 UTC
++++ src/port_audio.cpp
+@@ -26,7 +26,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#if !defined(__APPLE__) && !defined(WIN32)
++#if !defined(__APPLE__) && !defined(WIN32) && defined(HAVE_JACK)
+ #include <pa_jack.h>
+ #endif
+ 
+@@ -130,7 +130,7 @@ int snd_init(void)
+ {
+     char info_buf[256];
+ 
+-#if !defined(__APPLE__) && !defined(WIN32) // JACK: Set client name before Pa_Initialize
++#if !defined(__APPLE__) && !defined(WIN32) && defined(HAVE_JACK) // JACK: Set client name before Pa_Initialize
+     if (jack_client_name != NULL && strlen(jack_client_name) > 0) {
+         PaJack_SetClientName(jack_client_name);
+     }


### PR DESCRIPTION
BUTT depends on `audio/portaudio` with JACK enabled as of 1.47. PortAudio isn't built with JACK support by default, so BUTT's build fails in CI.

I added an option to toggle JACK which fixes the build by making the new requirement explicit. I patched the source to disable the hard dependency on JACK - it was already disabled for Windows and macOS anyway so that was easy to do.

JACK is not enabled by default in the port because audio/portaudio requires JACK enabled as well.


---

Additional context that I'm not including in the commit message.

* [Ports Fallout](https://portsfallout.com/port/multimedia/butt/)
* I tested it with poudriere with a FreeBSD 15 jail. I did not test other architectures.
* This package name is way too funny.