### PR TITLE
sysutils/dockerbox-broker: add new port

### DIFF
--- a/sysutils/dockerbox-broker/Makefile
+++ b/sysutils/dockerbox-broker/Makefile
@@ -1,0 +1,30 @@
+PORTNAME=	dockerbox-broker
+DISTVERSIONPREFIX=	v
+DISTVERSION=	0.1.0
+CATEGORIES=	sysutils
+
+MAINTAINER=	leafoliage@FreeBSD.org
+COMMENT=	Port forwarding daemon for dockerbox
+WWW=		https://github.com/leafoliage/dockerbox-broker
+
+LICENSE=	BSD2CLAUSE
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+ONLY_FOR_ARCHS=	amd64
+
+USES=		go:1.25+,modules
+USE_GITHUB=	nodefault
+GH_ACCOUNT=	leafoliage
+GH_PROJECT=	dockerbox-broker
+
+GO_MODULE=	github.com/leafoliage/dockerbox-broker
+GO_TARGET=	.:${PREFIX}/sbin/${PORTNAME}
+
+post-install:
+	@${MKDIR} ${STAGEDIR}${ETCDIR}
+	${INSTALL_DATA} ${WRKSRC}/.env.sample \
+		${STAGEDIR}${ETCDIR}/${PORTNAME}.env.sample
+	${INSTALL_DATA} -m 0755 ${WRKSRC}/rc.d/${PORTNAME} \
+		${STAGEDIR}${PREFIX}/etc/rc.d/${PORTNAME}
+
+.include <bsd.port.mk>

--- a/sysutils/dockerbox-broker/distinfo
+++ b/sysutils/dockerbox-broker/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1788274295
+SHA256 (go/sysutils_dockerbox-broker/dockerbox-broker-v0.1.0/v0.1.0.mod) = 5587f96eb67314c9bd4f5b3f775ad51a30dd2be96fcb52a836e5e7684a741507
+SIZE (go/sysutils_dockerbox-broker/dockerbox-broker-v0.1.0/v0.1.0.mod) = 96
+SHA256 (go/sysutils_dockerbox-broker/dockerbox-broker-v0.1.0/v0.1.0.zip) = 129c33b380bb1c9d4dd0e0e6eb5a119fef8f573a4a0a01277b74cd0f2fe748b7
+SIZE (go/sysutils_dockerbox-broker/dockerbox-broker-v0.1.0/v0.1.0.zip) = 19244

--- a/sysutils/dockerbox-broker/pkg-descr
+++ b/sysutils/dockerbox-broker/pkg-descr
@@ -1,0 +1,2 @@
+Dockerbox-broker forwards a host port's traffic to dockerbox's port
+when a docker container port binding is specified.

--- a/sysutils/dockerbox-broker/pkg-plist
+++ b/sysutils/dockerbox-broker/pkg-plist
@@ -1,0 +1,3 @@
+@sample etc/dockerbox-broker/dockerbox-broker.env.sample
+etc/rc.d/dockerbox-broker
+sbin/dockerbox-broker


### PR DESCRIPTION
dockerbox-broker is child service of freebsd-dockerbox that maintains port forwarding.

@lwhsu 