### PR TITLE
security/openvpn: security update to v2.7.7

### DIFF
--- a/security/openvpn/Makefile
+++ b/security/openvpn/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=		openvpn
-DISTVERSION=		2.7.6
+DISTVERSION=		2.7.7
 PORTREVISION=		0
 CATEGORIES=		security net net-vpn
 MASTER_SITES=		https://swupdate.openvpn.org/community/releases/ \

--- a/security/openvpn/distinfo
+++ b/security/openvpn/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1786867665
-SHA256 (openvpn-2.7.6.tar.gz) = 10e24a9385f23cc38cc5cf448f3ca0769f939bc4cbecc4f4647d7e006e52db74
-SIZE (openvpn-2.7.6.tar.gz) = 2105678
+TIMESTAMP = 1788462723
+SHA256 (openvpn-2.7.7.tar.gz) = 3ab8f48fd6c26d49ba2333a092433949afdb5c85c0e6a1ff265784fbc04a2463
+SIZE (openvpn-2.7.7.tar.gz) = 2128305


### PR DESCRIPTION
```
Changelog:	https://github.com/OpenVPN/openvpn/blob/v2.7.7/Changes.rst#overview-of-changes-in-277

Security:       CVE-2026-84732
PR:             298152
MFH:            2026Q3
Pull request:   https://github.com/freebsd/freebsd-ports/pull/610
```