### PR TITLE
misc/py-crewai-tools: use pytest-asyncio for tests

### DIFF
--- a/misc/py-crewai-tools/Makefile
+++ b/misc/py-crewai-tools/Makefile
@@ -22,7 +22,7 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}beautifulsoup4>=4.13.4:www/py-beautifulsoup4
 		${PYTHON_PKGNAMEPREFIX}requests>=2.33.0:www/py-requests@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}tiktoken>=0.8.0:textproc/py-tiktoken@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}youtube-transcript-api>=1.2.2:www/py-youtube-transcript-api@${PY_FLAVOR}
-TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}anyio>0:devel/py-anyio@${PY_FLAVOR}
+TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pytest-asyncio>0:devel/py-pytest-asyncio@${PY_FLAVOR}
 
 USES=		python
 USE_PYTHON=	autoplist concurrent pep517 pytest
@@ -31,8 +31,9 @@ NO_ARCH=	yes
 
 TEST_ENV=	${MAKE_ENV} PYTHONPATH=${STAGEDIR}${PYTHONPREFIX_SITELIBDIR}
 TEST_WRKSRC=	${WRKSRC}/tests
-# adding the args --disable-plugin-autoload -p anyio causes tests to fail, see https://github.com/crewAIInc/crewAI/issues/7305
-TEST_ARGS=	--ignore=adapters/mcp_adapter_test.py \
+TEST_ARGS=	--disable-plugin-autoload \
+		-p pytest_asyncio.plugin \
+		--ignore=adapters/mcp_adapter_test.py \
 		--ignore=base_tool_test.py \
 		--ignore=tools/brave_search_tool_test.py \
 		--ignore=tools/couchbase_tool_test.py \


### PR DESCRIPTION
## Summary

- replace the AnyIO test dependency with pytest-asyncio, matching the upstream test markers
- disable plugin autoload and explicitly load pytest_asyncio.plugin
- remove the obsolete comment referencing crewAIInc/crewAI#7305

## Rationale

The two asynchronous WaitTool tests are marked with pytest.mark.asyncio. Upstream clarified in crewAIInc/crewAI#7305 and #7307 that the suite uses pytest-asyncio and that downstream test runs should load that plugin rather than switch those tests to AnyIO.

With plugin autoload disabled, the importable pytest plugin entry point is pytest_asyncio.plugin.

## Verification

- Targeted PyPI sdist command: python -m pytest --disable-plugin-autoload -p pytest_asyncio.plugin tests/tools/wait_tool_test.py -q
- Result: 23 passed
- Broader Windows run with the port ignore list: 535 passed, 2 skipped, and 6 unrelated Windows file permission/path failures

FreeBSD/poudriere verification has not been run locally.