### PR TITLE
Rename tass64 binary back to 64tass

### DIFF
--- a/devel/tass64/Makefile
+++ b/devel/tass64/Makefile
@@ -19,13 +19,13 @@ USES=		gmake zip
 
 MAKE_ARGS=	-w CC="${CC}" CFLAGS="${CFLAGS}" LD="${CC}" LDFLAGS="${LDFLAGS}"
 
-PLIST_FILES=	bin/tass64
+PLIST_FILES=	bin/64tass
 PORTDOCS=	README README.html README.md
 
 OPTIONS_DEFINE=	DOCS
 
 do-install:
-	${INSTALL_PROGRAM} ${WRKSRC}/64tass ${STAGEDIR}${PREFIX}/bin/tass64
+	${INSTALL_PROGRAM} ${WRKSRC}/64tass ${STAGEDIR}${PREFIX}/bin/64tass
 
 do-install-DOCS-on:
 	${MKDIR} ${STAGEDIR}${DOCSDIR}


### PR DESCRIPTION
Upstream produces the binary as "64tass" but for some reason this port has always renamed the binary to "tass64" with no explanation that I can find.

Other utilities, such as the Prog8 compiler directly call "64tass" for their linker. I am actively porting the Prog8 compiler to FreeBSD to do 6502/65c816 development for the Commander X16 / OtterX modern-retro platforms.

I'm proposing we rename the binary back to "64tass" as defined by the upstream project to ensure compatibility with other utilities and build systems such as Prog8.